### PR TITLE
Update Windows Facter 3.x sets with legacy facts

### DIFF
--- a/facts/3.0/windows-10-i386.facts
+++ b/facts/3.0/windows-10-i386.facts
@@ -1,32 +1,64 @@
 {
+  "architecture": "x86",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 ca fe f0 e7 64 ba-7e c1 ac 81 ec 79 2a c9"
+      "serial_number": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.0.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "i686",
+  "hostname": "foo",
+  "id": "CAYR11ES3BMJ6UG\\Administrator",
   "identity": {
-    "user": "CD9O9NMEXAPI3GF\\Administrator"
+    "user": "CAYR11ES3BMJ6UG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.121.213",
+  "ipaddress6": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress6_Ethernet0": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress_Ethernet0": "10.32.121.213",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:72:55",
+  "macaddress_Ethernet0": "00:50:56:A2:72:55",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.00 GiB",
-      "available_bytes": 2146865152,
-      "capacity": "33.33%",
+      "available": "1.95 GiB",
+      "available_bytes": 2097065984,
+      "capacity": "34.88%",
       "total": "3.00 GiB",
       "total_bytes": 3220324352,
-      "used": "1023.73 MiB",
-      "used_bytes": 1073459200
+      "used": "1.05 GiB",
+      "used_bytes": 1123258368
     }
   },
+  "memoryfree": "1.95 GiB",
+  "memoryfree_mb": 1999.92,
+  "memorysize": "3.00 GiB",
+  "memorysize_mb": 3071.14,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -35,25 +67,28 @@
     "interfaces": {
       "Ethernet0": {
         "dhcp": "10.32.22.10",
-        "ip": "10.32.120.121",
-        "ip6": "fe80::45d7:5af5:8f53:8392%5",
-        "mac": "00:50:56:A2:D4:F1",
+        "ip": "10.32.121.213",
+        "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+        "mac": "00:50:56:A2:72:55",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%5"
+        "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.120.121",
-    "ip6": "fe80::45d7:5af5:8f53:8392%5",
-    "mac": "00:50:56:A2:D4:F1",
+    "ip": "10.32.121.213",
+    "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+    "mac": "00:50:56:A2:72:55",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%5"
+    "network6": "fe80::%3"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10.0.14393",
+  "operatingsystemrelease": "10.0.14393",
   "os": {
     "architecture": "x86",
     "family": "windows",
@@ -67,7 +102,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -77,20 +117,27 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "ruby": {
     "platform": "i386-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.6"
   },
+  "rubyplatform": "i386-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.6",
+  "serialnumber": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 1134,
-    "uptime": "0:18 hours"
+    "hours": 6,
+    "seconds": 23438,
+    "uptime": "6:30 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:30 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 23438,
+  "virtual": "vmware"
 }

--- a/facts/3.0/windows-10-x86_64.facts
+++ b/facts/3.0/windows-10-x86_64.facts
@@ -1,32 +1,64 @@
 {
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 b9 12 ec 3b 6e ab-61 61 29 cf f4 72 99 c3"
+      "serial_number": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.0.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "V46YN43Q8ZY3NYG\\Administrator",
   "identity": {
-    "user": "PQX8SDC5TGXO8LI\\Administrator"
+    "user": "V46YN43Q8ZY3NYG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.130",
+  "ipaddress6": "fe80::e110:a74a:480:4409%4",
+  "ipaddress6_Ethernet0": "fe80::e110:a74a:480:4409%4",
+  "ipaddress_Ethernet0": "10.32.112.130",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:BB:13",
+  "macaddress_Ethernet0": "00:50:56:A2:BB:13",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.84 GiB",
-      "available_bytes": 3047428096,
-      "capacity": "29.03%",
+      "available": "2.72 GiB",
+      "available_bytes": 2918952960,
+      "capacity": "32.02%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "1.16 GiB",
-      "used_bytes": 1246629888
+      "used": "1.28 GiB",
+      "used_bytes": 1375105024
     }
   },
+  "memoryfree": "2.72 GiB",
+  "memoryfree_mb": 2783.73,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.13,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%4",
+  "network6_Ethernet0": "fe80::%4",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -35,25 +67,28 @@
     "interfaces": {
       "Ethernet0": {
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.158",
-        "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-        "mac": "00:50:56:A2:B1:5B",
+        "ip": "10.32.112.130",
+        "ip6": "fe80::e110:a74a:480:4409%4",
+        "mac": "00:50:56:A2:BB:13",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%2"
+        "network6": "fe80::%4"
       }
     },
-    "ip": "10.32.113.158",
-    "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-    "mac": "00:50:56:A2:B1:5B",
+    "ip": "10.32.112.130",
+    "ip6": "fe80::e110:a74a:480:4409%4",
+    "mac": "00:50:56:A2:BB:13",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%2"
+    "network6": "fe80::%4"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10.0.14393",
+  "operatingsystemrelease": "10.0.14393",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -67,30 +102,42 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.6"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.6",
+  "serialnumber": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 16,
-    "seconds": 57809,
-    "uptime": "16:03 hours"
+    "hours": 6,
+    "seconds": 23255,
+    "uptime": "6:27 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:27 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 23255,
+  "virtual": "vmware"
 }

--- a/facts/3.0/windows-2008 r2-x86_64.facts
+++ b/facts/3.0/windows-2008 r2-x86_64.facts
@@ -1,32 +1,64 @@
 {
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 6f a5 43 75 12 ae-15 76 ec 76 47 5d 25 9a"
+      "serial_number": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.0.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "RJ2WFCMG7UF17CW\\Administrator",
   "identity": {
-    "user": "HKB7CU8PWYEHS3A\\Administrator"
+    "user": "RJ2WFCMG7UF17CW\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.127.75",
+  "ipaddress6": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress6_Local Area Connection": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress_Local Area Connection": "10.32.127.75",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:06:09",
+  "macaddress_Local Area Connection": "00:50:56:A2:06:09",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.03 GiB",
-      "available_bytes": 3252813824,
-      "capacity": "24.25%",
+      "available": "3.09 GiB",
+      "available_bytes": 3314180096,
+      "capacity": "22.82%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "993.02 MiB",
-      "used_bytes": 1041252352
+      "used": "934.49 MiB",
+      "used_bytes": 979886080
     }
   },
+  "memoryfree": "3.09 GiB",
+  "memoryfree_mb": 3160.65,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.14,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -35,25 +67,28 @@
     "interfaces": {
       "Local Area Connection": {
         "dhcp": "10.32.22.10",
-        "ip": "10.32.116.113",
-        "ip6": "fe80::60bc:b13:61bf:9110%12",
-        "mac": "00:50:56:A2:C2:80",
+        "ip": "10.32.127.75",
+        "ip6": "fe80::80be:a6bc:1766:4c99%11",
+        "mac": "00:50:56:A2:06:09",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%12"
+        "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.116.113",
-    "ip6": "fe80::60bc:b13:61bf:9110%12",
-    "mac": "00:50:56:A2:C2:80",
+    "ip": "10.32.127.75",
+    "ip6": "fe80::80be:a6bc:1766:4c99%11",
+    "mac": "00:50:56:A2:06:09",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%12"
+    "network6": "fe80::%11"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008 R2",
+  "operatingsystemrelease": "2008 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -67,7 +102,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -77,20 +117,27 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.6"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.6",
+  "serialnumber": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 607,
-    "uptime": "0:10 hours"
+    "hours": 16,
+    "seconds": 60502,
+    "uptime": "16:48 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "16:48 hours",
+  "uptime_days": 0,
+  "uptime_hours": 16,
+  "uptime_seconds": 60502,
+  "virtual": "vmware"
 }

--- a/facts/3.0/windows-2008-x86_64.facts
+++ b/facts/3.0/windows-2008-x86_64.facts
@@ -1,32 +1,64 @@
 {
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "Phoenix Technologies LTD",
     "product": {
       "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 3f 06 9e 43 30 eb-b3 f4 58 de 6a 3e e5 9f"
+      "serial_number": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.0.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "QFMZ60DYQGU893J\\Administrator",
   "identity": {
-    "user": "D5NOW95YYUDLWEV\\Administrator"
+    "user": "QFMZ60DYQGU893J\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.95",
+  "ipaddress6": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress6_Local Area Connection": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress_Local Area Connection": "10.32.126.95",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.0",
   "kernelrelease": "6.0.6002",
   "kernelversion": "6.0.6002",
+  "macaddress": "00:50:56:A2:E0:07",
+  "macaddress_Local Area Connection": "00:50:56:A2:E0:07",
+  "manufacturer": "Phoenix Technologies LTD",
   "memory": {
     "system": {
-      "available": "3.16 GiB",
-      "available_bytes": 3396591616,
-      "capacity": "20.89%",
+      "available": "3.19 GiB",
+      "available_bytes": 3424223232,
+      "capacity": "20.24%",
       "total": "4.00 GiB",
       "total_bytes": 4293357568,
-      "used": "855.22 MiB",
-      "used_bytes": 896765952
+      "used": "828.87 MiB",
+      "used_bytes": 869134336
     }
   },
+  "memoryfree": "3.19 GiB",
+  "memoryfree_mb": 3265.59,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4094.46,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%10",
+  "network6_Local Area Connection": "fe80::%10",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -35,25 +67,28 @@
     "interfaces": {
       "Local Area Connection": {
         "dhcp": "10.32.22.10",
-        "ip": "10.32.117.107",
-        "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-        "mac": "00:50:56:A2:B1:DA",
+        "ip": "10.32.126.95",
+        "ip6": "fe80::dd24:f5a9:347b:c256%10",
+        "mac": "00:50:56:A2:E0:07",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%11"
+        "network6": "fe80::%10"
       }
     },
-    "ip": "10.32.117.107",
-    "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-    "mac": "00:50:56:A2:B1:DA",
+    "ip": "10.32.126.95",
+    "ip6": "fe80::dd24:f5a9:347b:c256%10",
+    "mac": "00:50:56:A2:E0:07",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%11"
+    "network6": "fe80::%10"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008",
+  "operatingsystemrelease": "2008",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -67,30 +102,42 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware Virtual Platform",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.6"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.6",
+  "serialnumber": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 15,
-    "seconds": 55169,
-    "uptime": "15:19 hours"
+    "hours": 14,
+    "seconds": 50808,
+    "uptime": "14:06 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "14:06 hours",
+  "uptime_days": 0,
+  "uptime_hours": 14,
+  "uptime_seconds": 50808,
+  "virtual": "vmware"
 }

--- a/facts/3.0/windows-2012 r2-core-x86_64.facts
+++ b/facts/3.0/windows-2012 r2-core-x86_64.facts
@@ -1,43 +1,75 @@
 {
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
-    "manufacturer": "Phoenix Technologies LTD",
+    "manufacturer": "VMware, Inc.",
     "product": {
-      "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 91 42 5a d1 7a 50-73 d9 8a 73 2a ba e5 d9"
+      "name": "VMware7,1",
+      "serial_number": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.0.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "G0ZBZXENEIL32X5\\Administrator",
   "identity": {
-    "user": "GHWYJ7383D7T8XY\\cyg_server"
+    "user": "G0ZBZXENEIL32X5\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.117.89",
+  "ipaddress6": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress6_Ethernet0": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress_Ethernet0": "10.32.117.89",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:72:05",
+  "macaddress_Ethernet0": "00:50:56:A2:72:05",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.13 GiB",
-      "available_bytes": 3362283520,
-      "capacity": "21.71%",
-      "total": "4.00 GiB",
-      "total_bytes": 4294496256,
-      "used": "889.03 MiB",
-      "used_bytes": 932212736
+      "available": "5.42 GiB",
+      "available_bytes": 5819777024,
+      "capacity": "9.65%",
+      "total": "6.00 GiB",
+      "total_bytes": 6441549824,
+      "used": "592.97 MiB",
+      "used_bytes": 621772800
     }
   },
+  "memoryfree": "5.42 GiB",
+  "memoryfree_mb": 5550.17,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.14,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
-      "Ethernet": {
+      "Ethernet0": {
         "dhcp": "10.32.22.10",
-        "ip": "10.32.114.127",
-        "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-        "mac": "00:50:56:A2:34:6A",
+        "ip": "10.32.117.89",
+        "ip6": "fe80::71c4:5555:d38:94fa%12",
+        "mac": "00:50:56:A2:72:05",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -45,15 +77,18 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.114.127",
-    "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-    "mac": "00:50:56:A2:34:6A",
+    "ip": "10.32.117.89",
+    "ip6": "fe80::71c4:5555:d38:94fa%12",
+    "mac": "00:50:56:A2:72:05",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
     "network6": "fe80::%12"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -67,7 +102,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\pstools;C:\\cygwin64\\bin",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -77,20 +117,27 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.6"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.6",
+  "serialnumber": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 0,
-    "hours": 11,
-    "seconds": 41661,
-    "uptime": "11:34 hours"
+    "days": 1,
+    "hours": 24,
+    "seconds": 87036,
+    "uptime": "1 day"
   },
-  "timezone": "Pacific Daylight Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "timezone": "Coordinated Universal Time",
+  "uptime": "1 day",
+  "uptime_days": 1,
+  "uptime_hours": 24,
+  "uptime_seconds": 87036,
+  "virtual": "vmware"
 }

--- a/facts/3.0/windows-2012 r2-x86_64.facts
+++ b/facts/3.0/windows-2012 r2-x86_64.facts
@@ -1,68 +1,94 @@
 {
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
-    "manufacturer": "innotek GmbH",
+    "manufacturer": "VMware, Inc.",
     "product": {
-      "name": "VirtualBox",
-      "serial_number": "0"
+      "name": "VMware7,1",
+      "serial_number": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.0.2",
   "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GTT427VBINBGPOL\\Administrator",
   "identity": {
-    "user": "FOO\\vagrant"
+    "user": "GTT427VBINBGPOL\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.127.212",
+  "ipaddress6": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress6_Ethernet0": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress_Ethernet0": "10.32.127.212",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:D9:94",
+  "macaddress_Ethernet0": "00:50:56:A2:D9:94",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "411.78 MiB",
-      "available_bytes": 431779840,
-      "capacity": "59.77%",
-      "total": "1023.55 MiB",
-      "total_bytes": 1073274880,
-      "used": "611.78 MiB",
-      "used_bytes": 641495040
+      "available": "5.30 GiB",
+      "available_bytes": 5685829632,
+      "capacity": "11.73%",
+      "total": "6.00 GiB",
+      "total_bytes": 6441549824,
+      "used": "720.71 MiB",
+      "used_bytes": 755720192
     }
   },
+  "memoryfree": "5.30 GiB",
+  "memoryfree_mb": 5422.43,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.14,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
-    "fqdn": "foo",
+    "dhcp": "10.32.22.10",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
-      "Ethernet": {
-        "dhcp": "10.0.2.2",
-        "ip": "10.0.2.15",
-        "ip6": "fe80::6054:1dfe:23d3:e74c%12",
-        "mac": "08:00:27:A4:27:B4",
+      "Ethernet0": {
+        "dhcp": "10.32.22.10",
+        "ip": "10.32.127.212",
+        "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+        "mac": "00:50:56:A2:D9:94",
         "mtu": 1500,
-        "netmask": "255.255.255.0",
+        "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.0.2.0",
+        "network": "10.32.112.0",
         "network6": "fe80::%12"
-      },
-      "Ethernet 2": {
-        "ip": "10.20.1.5",
-        "ip6": "fe80::d925:4b7b:603e:87cd%13",
-        "mac": "08:00:27:8C:BB:02",
-        "mtu": 1500,
-        "netmask": "255.255.255.0",
-        "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.20.1.0",
-        "network6": "fe80::%13"
       }
     },
-    "ip": "10.20.1.5",
-    "ip6": "fe80::d925:4b7b:603e:87cd%13",
-    "mac": "08:00:27:8C:BB:02",
+    "ip": "10.32.127.212",
+    "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+    "mac": "00:50:56:A2:D9:94",
     "mtu": 1500,
-    "netmask": "255.255.255.0",
+    "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
-    "network": "10.20.1.0",
-    "network6": "fe80::%13"
+    "network": "10.32.112.0",
+    "network6": "fe80::%12"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -76,26 +102,42 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\ProgramData\\chocolatey\\bin;C:\\Users\\vagrant\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
-    "physicalcount": 1
+    "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.6"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.6",
+  "serialnumber": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 131,
-    "uptime": "0:02 hours"
+    "seconds": 1827,
+    "uptime": "0:30 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "virtualbox"
+  "uptime": "0:30 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 1827,
+  "virtual": "vmware"
 }

--- a/facts/3.0/windows-2012-x86_64.facts
+++ b/facts/3.0/windows-2012-x86_64.facts
@@ -1,32 +1,64 @@
 {
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d0 54 b4 68 27 15-5e 55 a0 aa a1 c4 b6 85"
+      "serial_number": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.0.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "WX8QEA42SDYVTT6\\Administrator",
   "identity": {
-    "user": "O1JC0NKUU0IWW8R\\Administrator"
+    "user": "WX8QEA42SDYVTT6\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.136",
+  "ipaddress6": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress6_Ethernet0": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress_Ethernet0": "10.32.112.136",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.2",
   "kernelrelease": "6.2.9200",
   "kernelversion": "6.2.9200",
+  "macaddress": "00:50:56:A2:5B:88",
+  "macaddress_Ethernet0": "00:50:56:A2:5B:88",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.29 GiB",
-      "available_bytes": 3530330112,
-      "capacity": "17.79%",
+      "available": "3.34 GiB",
+      "available_bytes": 3584352256,
+      "capacity": "16.53%",
       "total": "4.00 GiB",
       "total_bytes": 4294062080,
-      "used": "728.35 MiB",
-      "used_bytes": 763731968
+      "used": "676.83 MiB",
+      "used_bytes": 709709824
     }
   },
+  "memoryfree": "3.34 GiB",
+  "memoryfree_mb": 3418.3,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.14,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -35,25 +67,28 @@
     "interfaces": {
       "Ethernet0": {
         "dhcp": "10.32.22.10",
-        "ip": "10.32.115.189",
-        "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-        "mac": "00:50:56:A2:92:62",
+        "ip": "10.32.112.136",
+        "ip6": "fe80::256a:cde6:f021:6c49%12",
+        "mac": "00:50:56:A2:5B:88",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%13"
+        "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.115.189",
-    "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-    "mac": "00:50:56:A2:92:62",
+    "ip": "10.32.112.136",
+    "ip6": "fe80::256a:cde6:f021:6c49%12",
+    "mac": "00:50:56:A2:5B:88",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%13"
+    "network6": "fe80::%12"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012",
+  "operatingsystemrelease": "2012",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -67,30 +102,42 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.6"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.6",
+  "serialnumber": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 12,
-    "seconds": 46712,
-    "uptime": "12:58 hours"
+    "hours": 15,
+    "seconds": 54833,
+    "uptime": "15:13 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "15:13 hours",
+  "uptime_days": 0,
+  "uptime_hours": 15,
+  "uptime_seconds": 54833,
+  "virtual": "vmware"
 }

--- a/facts/3.0/windows-2016-x86_64.facts
+++ b/facts/3.0/windows-2016-x86_64.facts
@@ -1,32 +1,64 @@
 {
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d8 fb 34 7b b4 e8-dd 91 bd ef cc 32 1e 6c"
+      "serial_number": "VMware-42 22 7d 13 91 74 de e9-6d 4f f8 e5 16 ac c0 3d"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.0.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "BDJW8R9XH6J2GEZ\\Administrator",
   "identity": {
-    "user": "IHGAJGT1OU8FTDM\\Administrator"
+    "user": "BDJW8R9XH6J2GEZ\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.121.121",
+  "ipaddress6": "fe80::650e:ed97:4042:6bd2%5",
+  "ipaddress6_Ethernet0": "fe80::650e:ed97:4042:6bd2%5",
+  "ipaddress_Ethernet0": "10.32.121.121",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:23:59",
+  "macaddress_Ethernet0": "00:50:56:A2:23:59",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.05 GiB",
-      "available_bytes": 3272458240,
-      "capacity": "23.79%",
+      "available": "2.97 GiB",
+      "available_bytes": 3194155008,
+      "capacity": "25.61%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "974.27 MiB",
-      "used_bytes": 1021599744
+      "used": "1.02 GiB",
+      "used_bytes": 1099902976
     }
   },
+  "memoryfree": "2.97 GiB",
+  "memoryfree_mb": 3046.18,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.13,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%5",
+  "network6_Ethernet0": "fe80::%5",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -35,25 +67,28 @@
     "interfaces": {
       "Ethernet0": {
         "dhcp": "10.32.22.10",
-        "ip": "10.32.119.232",
-        "ip6": "fe80::99c3:c512:bd3:5f63%3",
-        "mac": "00:50:56:A2:68:15",
+        "ip": "10.32.121.121",
+        "ip6": "fe80::650e:ed97:4042:6bd2%5",
+        "mac": "00:50:56:A2:23:59",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%3"
+        "network6": "fe80::%5"
       }
     },
-    "ip": "10.32.119.232",
-    "ip6": "fe80::99c3:c512:bd3:5f63%3",
-    "mac": "00:50:56:A2:68:15",
+    "ip": "10.32.121.121",
+    "ip6": "fe80::650e:ed97:4042:6bd2%5",
+    "mac": "00:50:56:A2:23:59",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%3"
+    "network6": "fe80::%5"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10.0.14393",
+  "operatingsystemrelease": "10.0.14393",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -67,7 +102,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -77,20 +117,27 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.6"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.6",
+  "serialnumber": "VMware-42 22 7d 13 91 74 de e9-6d 4f f8 e5 16 ac c0 3d",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 1,
-    "seconds": 4890,
-    "uptime": "1:21 hours"
+    "hours": 16,
+    "seconds": 60292,
+    "uptime": "16:44 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "uptime": "16:44 hours",
+  "uptime_days": 0,
+  "uptime_hours": 16,
+  "uptime_seconds": 60292,
+  "virtual": "vmware"
 }

--- a/facts/3.0/windows-7-x86_64.facts
+++ b/facts/3.0/windows-7-x86_64.facts
@@ -1,68 +1,94 @@
 {
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
-    "manufacturer": "innotek GmbH",
+    "manufacturer": "VMware, Inc.",
     "product": {
-      "name": "VirtualBox",
-      "serial_number": "0"
+      "name": "VMware7,1",
+      "serial_number": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.0.2",
   "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "N6IFGFZXW976ITI\\Administrator",
   "identity": {
-    "user": "FOO\\vagrant"
+    "user": "N6IFGFZXW976ITI\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.90",
+  "ipaddress6": "fe80::2121:2899:8986:e379%11",
+  "ipaddress6_Local Area Connection": "fe80::2121:2899:8986:e379%11",
+  "ipaddress_Local Area Connection": "10.32.126.90",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
-  "kernelrelease": "6.1.7600",
-  "kernelversion": "6.1.7600",
+  "kernelrelease": "6.1.7601",
+  "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:78:83",
+  "macaddress_Local Area Connection": "00:50:56:A2:78:83",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "278.74 MiB",
-      "available_bytes": 292278272,
-      "capacity": "72.77%",
-      "total": "1023.55 MiB",
-      "total_bytes": 1073274880,
-      "used": "744.82 MiB",
-      "used_bytes": 780996608
+      "available": "3.04 GiB",
+      "available_bytes": 3261620224,
+      "capacity": "24.04%",
+      "total": "4.00 GiB",
+      "total_bytes": 4294066176,
+      "used": "984.62 MiB",
+      "used_bytes": 1032445952
     }
   },
+  "memoryfree": "3.04 GiB",
+  "memoryfree_mb": 3110.52,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.14,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
-    "fqdn": "foo",
+    "dhcp": "10.32.22.10",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
       "Local Area Connection": {
-        "dhcp": "10.0.2.2",
-        "ip": "10.0.2.15",
-        "ip6": "fe80::700d:3fab:1d54:dc0d%11",
-        "mac": "08:00:27:67:C8:1B",
+        "dhcp": "10.32.22.10",
+        "ip": "10.32.126.90",
+        "ip6": "fe80::2121:2899:8986:e379%11",
+        "mac": "00:50:56:A2:78:83",
         "mtu": 1500,
-        "netmask": "255.255.255.0",
+        "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.0.2.0",
+        "network": "10.32.112.0",
         "network6": "fe80::%11"
-      },
-      "Local Area Connection 3": {
-        "ip": "10.20.1.5",
-        "ip6": "fe80::15ec:2eb0:42ca:d968%13",
-        "mac": "08:00:27:81:BB:CB",
-        "mtu": 1500,
-        "netmask": "255.255.255.0",
-        "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.20.1.0",
-        "network6": "fe80::%13"
       }
     },
-    "ip": "10.20.1.5",
-    "ip6": "fe80::15ec:2eb0:42ca:d968%13",
-    "mac": "08:00:27:81:BB:CB",
+    "ip": "10.32.126.90",
+    "ip6": "fe80::2121:2899:8986:e379%11",
+    "mac": "00:50:56:A2:78:83",
     "mtu": 1500,
-    "netmask": "255.255.255.0",
+    "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
-    "network": "10.20.1.0",
-    "network6": "fe80::%13"
+    "network": "10.32.112.0",
+    "network6": "fe80::%11"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "7",
+  "operatingsystemrelease": "7",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -76,26 +102,42 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files (x86)\\Git\\bin; ",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
-    "count": 1,
+    "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
-    "physicalcount": 1
+    "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.6"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.6",
+  "serialnumber": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 119,
-    "uptime": "0:01 hours"
+    "hours": 8,
+    "seconds": 29530,
+    "uptime": "8:12 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "virtualbox"
+  "uptime": "8:12 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29530,
+  "virtual": "vmware"
 }

--- a/facts/3.0/windows-8.1-x86_64.facts
+++ b/facts/3.0/windows-8.1-x86_64.facts
@@ -1,43 +1,75 @@
 {
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 0f 99 71 37 c9 34 5c-60 e2 5f ad 59 28 d7 53"
+      "serial_number": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.0.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "B5GMZC25YP3WRFT\\Administrator",
   "identity": {
-    "user": "TGPX4C0ZOVOW6AL\\Administrator"
+    "user": "B5GMZC25YP3WRFT\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.84",
+  "ipaddress6": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress6_Ethernet0": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress_Ethernet0": "10.32.125.84",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:FD:34",
+  "macaddress_Ethernet0": "00:50:56:A2:FD:34",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.61 GiB",
-      "available_bytes": 2800570368,
-      "capacity": "34.78%",
+      "available": "2.51 GiB",
+      "available_bytes": 2692866048,
+      "capacity": "37.29%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.39 GiB",
-      "used_bytes": 1493495808
+      "used": "1.49 GiB",
+      "used_bytes": 1601200128
     }
   },
+  "memoryfree": "2.51 GiB",
+  "memoryfree_mb": 2568.12,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.14,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
-    "dhcp": "10.32.22.9",
+    "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
       "Ethernet0": {
-        "dhcp": "10.32.22.9",
-        "ip": "10.32.126.10",
-        "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-        "mac": "00:50:56:8F:42:E3",
+        "dhcp": "10.32.22.10",
+        "ip": "10.32.125.84",
+        "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+        "mac": "00:50:56:A2:FD:34",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -45,15 +77,18 @@
         "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.126.10",
-    "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-    "mac": "00:50:56:8F:42:E3",
+    "ip": "10.32.125.84",
+    "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+    "mac": "00:50:56:A2:FD:34",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
     "network6": "fe80::%3"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "8.1",
+  "operatingsystemrelease": "8.1",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -67,7 +102,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -77,20 +117,27 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.6"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.6",
+  "serialnumber": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 11,
-    "hours": 275,
-    "seconds": 993105,
-    "uptime": "11 days"
+    "days": 0,
+    "hours": 18,
+    "seconds": 66768,
+    "uptime": "18:32 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "18:32 hours",
+  "uptime_days": 0,
+  "uptime_hours": 18,
+  "uptime_seconds": 66768,
+  "virtual": "vmware"
 }

--- a/facts/3.1/windows-10-i386.facts
+++ b/facts/3.1/windows-10-i386.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x86",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 ca fe f0 e7 64 ba-7e c1 ac 81 ec 79 2a c9"
+      "serial_number": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.1.6",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "i686",
+  "hostname": "foo",
+  "id": "CAYR11ES3BMJ6UG\\Administrator",
   "identity": {
-    "user": "CD9O9NMEXAPI3GF\\Administrator"
+    "user": "CAYR11ES3BMJ6UG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.121.213",
+  "ipaddress6": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress6_Ethernet0": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress_Ethernet0": "10.32.121.213",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:72:55",
+  "macaddress_Ethernet0": "00:50:56:A2:72:55",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.02 GiB",
-      "available_bytes": 2164375552,
-      "capacity": "32.79%",
+      "available": "1.95 GiB",
+      "available_bytes": 2089054208,
+      "capacity": "35.13%",
       "total": "3.00 GiB",
       "total_bytes": 3220324352,
-      "used": "1007.03 MiB",
-      "used_bytes": 1055948800
+      "used": "1.05 GiB",
+      "used_bytes": 1131270144
     }
   },
+  "memoryfree": "1.95 GiB",
+  "memoryfree_mb": 1992.27734375,
+  "memorysize": "3.00 GiB",
+  "memorysize_mb": 3071.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +69,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.120.121",
+            "address": "10.32.121.213",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::45d7:5af5:8f53:8392%5",
+            "address": "fe80::4dab:3df1:6f45:ee04%3",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%5"
+            "network": "fe80::%3"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.120.121",
-        "ip6": "fe80::45d7:5af5:8f53:8392%5",
-        "mac": "00:50:56:A2:D4:F1",
+        "ip": "10.32.121.213",
+        "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+        "mac": "00:50:56:A2:72:55",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%5"
+        "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.120.121",
-    "ip6": "fe80::45d7:5af5:8f53:8392%5",
-    "mac": "00:50:56:A2:D4:F1",
+    "ip": "10.32.121.213",
+    "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+    "mac": "00:50:56:A2:72:55",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%5",
+    "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10.0.14393",
+  "operatingsystemrelease": "10.0.14393",
   "os": {
     "architecture": "x86",
     "family": "windows",
@@ -83,7 +118,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -93,21 +133,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.4.2",
   "ruby": {
     "platform": "i386-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.8"
   },
+  "rubyplatform": "i386-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.8",
+  "serialnumber": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 1081,
-    "uptime": "0:18 hours"
+    "hours": 6,
+    "seconds": 23393,
+    "uptime": "6:29 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:29 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 23393,
+  "virtual": "vmware"
 }

--- a/facts/3.1/windows-10-x86_64.facts
+++ b/facts/3.1/windows-10-x86_64.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 b9 12 ec 3b 6e ab-61 61 29 cf f4 72 99 c3"
+      "serial_number": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.1.6",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "V46YN43Q8ZY3NYG\\Administrator",
   "identity": {
-    "user": "PQX8SDC5TGXO8LI\\Administrator"
+    "user": "V46YN43Q8ZY3NYG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.130",
+  "ipaddress6": "fe80::e110:a74a:480:4409%4",
+  "ipaddress6_Ethernet0": "fe80::e110:a74a:480:4409%4",
+  "ipaddress_Ethernet0": "10.32.112.130",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:BB:13",
+  "macaddress_Ethernet0": "00:50:56:A2:BB:13",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.82 GiB",
-      "available_bytes": 3027333120,
-      "capacity": "29.50%",
+      "available": "2.71 GiB",
+      "available_bytes": 2909114368,
+      "capacity": "32.25%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "1.18 GiB",
-      "used_bytes": 1266724864
+      "used": "1.29 GiB",
+      "used_bytes": 1384943616
     }
   },
+  "memoryfree": "2.71 GiB",
+  "memoryfree_mb": 2774.34765625,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%4",
+  "network6_Ethernet0": "fe80::%4",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +69,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.113.158",
+            "address": "10.32.112.130",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::753c:44f6:3bb1:cb0c%2",
+            "address": "fe80::e110:a74a:480:4409%4",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%2"
+            "network": "fe80::%4"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.158",
-        "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-        "mac": "00:50:56:A2:B1:5B",
+        "ip": "10.32.112.130",
+        "ip6": "fe80::e110:a74a:480:4409%4",
+        "mac": "00:50:56:A2:BB:13",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%2"
+        "network6": "fe80::%4"
       }
     },
-    "ip": "10.32.113.158",
-    "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-    "mac": "00:50:56:A2:B1:5B",
+    "ip": "10.32.112.130",
+    "ip6": "fe80::e110:a74a:480:4409%4",
+    "mac": "00:50:56:A2:BB:13",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%2",
+    "network6": "fe80::%4",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10.0.14393",
+  "operatingsystemrelease": "10.0.14393",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,31 +118,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.4.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.8"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.8",
+  "serialnumber": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 16,
-    "seconds": 57763,
-    "uptime": "16:02 hours"
+    "hours": 6,
+    "seconds": 23210,
+    "uptime": "6:26 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:26 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 23210,
+  "virtual": "vmware"
 }

--- a/facts/3.1/windows-2008 r2-x86_64.facts
+++ b/facts/3.1/windows-2008 r2-x86_64.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 6f a5 43 75 12 ae-15 76 ec 76 47 5d 25 9a"
+      "serial_number": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.1.6",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "RJ2WFCMG7UF17CW\\Administrator",
   "identity": {
-    "user": "HKB7CU8PWYEHS3A\\Administrator"
+    "user": "RJ2WFCMG7UF17CW\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.127.75",
+  "ipaddress6": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress6_Local Area Connection": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress_Local Area Connection": "10.32.127.75",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:06:09",
+  "macaddress_Local Area Connection": "00:50:56:A2:06:09",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.99 GiB",
-      "available_bytes": 3208134656,
-      "capacity": "25.29%",
+      "available": "3.03 GiB",
+      "available_bytes": 3258269696,
+      "capacity": "24.12%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.01 GiB",
-      "used_bytes": 1085931520
+      "used": "987.81 MiB",
+      "used_bytes": 1035796480
     }
   },
+  "memoryfree": "3.03 GiB",
+  "memoryfree_mb": 3107.328125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +69,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.116.113",
+            "address": "10.32.127.75",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::60bc:b13:61bf:9110%12",
+            "address": "fe80::80be:a6bc:1766:4c99%11",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%12"
+            "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.116.113",
-        "ip6": "fe80::60bc:b13:61bf:9110%12",
-        "mac": "00:50:56:A2:C2:80",
+        "ip": "10.32.127.75",
+        "ip6": "fe80::80be:a6bc:1766:4c99%11",
+        "mac": "00:50:56:A2:06:09",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%12"
+        "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.116.113",
-    "ip6": "fe80::60bc:b13:61bf:9110%12",
-    "mac": "00:50:56:A2:C2:80",
+    "ip": "10.32.127.75",
+    "ip6": "fe80::80be:a6bc:1766:4c99%11",
+    "mac": "00:50:56:A2:06:09",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%12",
+    "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008 R2",
+  "operatingsystemrelease": "2008 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,7 +118,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -93,21 +133,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.4.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.8"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.8",
+  "serialnumber": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 552,
-    "uptime": "0:09 hours"
+    "hours": 16,
+    "seconds": 60457,
+    "uptime": "16:47 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "16:47 hours",
+  "uptime_days": 0,
+  "uptime_hours": 16,
+  "uptime_seconds": 60457,
+  "virtual": "vmware"
 }

--- a/facts/3.1/windows-2008-x86_64.facts
+++ b/facts/3.1/windows-2008-x86_64.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "Phoenix Technologies LTD",
     "product": {
       "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 3f 06 9e 43 30 eb-b3 f4 58 de 6a 3e e5 9f"
+      "serial_number": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.1.6",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "QFMZ60DYQGU893J\\Administrator",
   "identity": {
-    "user": "D5NOW95YYUDLWEV\\Administrator"
+    "user": "QFMZ60DYQGU893J\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.95",
+  "ipaddress6": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress6_Local Area Connection": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress_Local Area Connection": "10.32.126.95",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.0",
   "kernelrelease": "6.0.6002",
   "kernelversion": "6.0.6002",
+  "macaddress": "00:50:56:A2:E0:07",
+  "macaddress_Local Area Connection": "00:50:56:A2:E0:07",
+  "manufacturer": "Phoenix Technologies LTD",
   "memory": {
     "system": {
-      "available": "3.14 GiB",
-      "available_bytes": 3375190016,
-      "capacity": "21.39%",
+      "available": "3.17 GiB",
+      "available_bytes": 3405471744,
+      "capacity": "20.68%",
       "total": "4.00 GiB",
       "total_bytes": 4293357568,
-      "used": "875.63 MiB",
-      "used_bytes": 918167552
+      "used": "846.75 MiB",
+      "used_bytes": 887885824
     }
   },
+  "memoryfree": "3.17 GiB",
+  "memoryfree_mb": 3247.7109375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4094.46484375,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%10",
+  "network6_Local Area Connection": "fe80::%10",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +69,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.117.107",
+            "address": "10.32.126.95",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::e9c8:8f06:477c:99fa%11",
+            "address": "fe80::dd24:f5a9:347b:c256%10",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%11"
+            "network": "fe80::%10"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.117.107",
-        "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-        "mac": "00:50:56:A2:B1:DA",
+        "ip": "10.32.126.95",
+        "ip6": "fe80::dd24:f5a9:347b:c256%10",
+        "mac": "00:50:56:A2:E0:07",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%11"
+        "network6": "fe80::%10"
       }
     },
-    "ip": "10.32.117.107",
-    "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-    "mac": "00:50:56:A2:B1:DA",
+    "ip": "10.32.126.95",
+    "ip6": "fe80::dd24:f5a9:347b:c256%10",
+    "mac": "00:50:56:A2:E0:07",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%11",
+    "network6": "fe80::%10",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008",
+  "operatingsystemrelease": "2008",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,31 +118,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware Virtual Platform",
   "puppetversion": "4.4.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.8"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.8",
+  "serialnumber": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 15,
-    "seconds": 55103,
-    "uptime": "15:18 hours"
+    "hours": 14,
+    "seconds": 50743,
+    "uptime": "14:05 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "14:05 hours",
+  "uptime_days": 0,
+  "uptime_hours": 14,
+  "uptime_seconds": 50743,
+  "virtual": "vmware"
 }

--- a/facts/3.1/windows-2012 r2-core-x86_64.facts
+++ b/facts/3.1/windows-2012 r2-core-x86_64.facts
@@ -1,58 +1,90 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
-    "manufacturer": "Phoenix Technologies LTD",
+    "manufacturer": "VMware, Inc.",
     "product": {
-      "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 91 42 5a d1 7a 50-73 d9 8a 73 2a ba e5 d9"
+      "name": "VMware7,1",
+      "serial_number": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.1.6",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "G0ZBZXENEIL32X5\\Administrator",
   "identity": {
-    "user": "GHWYJ7383D7T8XY\\cyg_server"
+    "user": "G0ZBZXENEIL32X5\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.117.89",
+  "ipaddress6": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress6_Ethernet0": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress_Ethernet0": "10.32.117.89",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:72:05",
+  "macaddress_Ethernet0": "00:50:56:A2:72:05",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.12 GiB",
-      "available_bytes": 3350302720,
-      "capacity": "21.99%",
-      "total": "4.00 GiB",
-      "total_bytes": 4294496256,
-      "used": "900.45 MiB",
-      "used_bytes": 944193536
+      "available": "5.40 GiB",
+      "available_bytes": 5794500608,
+      "capacity": "10.04%",
+      "total": "6.00 GiB",
+      "total_bytes": 6441549824,
+      "used": "617.07 MiB",
+      "used_bytes": 647049216
     }
   },
+  "memoryfree": "5.40 GiB",
+  "memoryfree_mb": 5526.06640625,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
-      "Ethernet": {
+      "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.114.127",
+            "address": "10.32.117.89",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::fd0d:3323:1bb4:680d%12",
+            "address": "fe80::71c4:5555:d38:94fa%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.114.127",
-        "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-        "mac": "00:50:56:A2:34:6A",
+        "ip": "10.32.117.89",
+        "ip6": "fe80::71c4:5555:d38:94fa%12",
+        "mac": "00:50:56:A2:72:05",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -60,16 +92,19 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.114.127",
-    "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-    "mac": "00:50:56:A2:34:6A",
+    "ip": "10.32.117.89",
+    "ip6": "fe80::71c4:5555:d38:94fa%12",
+    "mac": "00:50:56:A2:72:05",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
     "network6": "fe80::%12",
-    "primary": "Ethernet"
+    "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,7 +118,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\pstools;C:\\cygwin64\\bin",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -93,21 +133,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.4.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.8"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.8",
+  "serialnumber": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 0,
-    "hours": 11,
-    "seconds": 41618,
-    "uptime": "11:33 hours"
+    "days": 1,
+    "hours": 24,
+    "seconds": 86996,
+    "uptime": "1 day"
   },
-  "timezone": "Pacific Daylight Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "timezone": "Coordinated Universal Time",
+  "uptime": "1 day",
+  "uptime_days": 1,
+  "uptime_hours": 24,
+  "uptime_seconds": 86996,
+  "virtual": "vmware"
 }

--- a/facts/3.1/windows-2012 r2-x86_64.facts
+++ b/facts/3.1/windows-2012 r2-x86_64.facts
@@ -1,97 +1,110 @@
 {
+  "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
-    "manufacturer": "innotek GmbH",
+    "manufacturer": "VMware, Inc.",
     "product": {
-      "name": "VirtualBox",
-      "serial_number": "0"
+      "name": "VMware7,1",
+      "serial_number": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
-  "facterversion": "3.1.5",
+  "facterversion": "3.1.6",
   "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GTT427VBINBGPOL\\Administrator",
   "identity": {
-    "user": "FOO\\vagrant"
+    "user": "GTT427VBINBGPOL\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.127.212",
+  "ipaddress6": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress6_Ethernet0": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress_Ethernet0": "10.32.127.212",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:D9:94",
+  "macaddress_Ethernet0": "00:50:56:A2:D9:94",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "337.39 MiB",
-      "available_bytes": 353775616,
-      "capacity": "67.04%",
-      "total": "1023.55 MiB",
-      "total_bytes": 1073274880,
-      "used": "686.17 MiB",
-      "used_bytes": 719499264
+      "available": "5.27 GiB",
+      "available_bytes": 5658914816,
+      "capacity": "12.15%",
+      "total": "6.00 GiB",
+      "total_bytes": 6441549824,
+      "used": "746.38 MiB",
+      "used_bytes": 782635008
     }
   },
+  "memoryfree": "5.27 GiB",
+  "memoryfree_mb": 5396.76171875,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
-    "fqdn": "foo",
+    "dhcp": "10.32.22.10",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
-      "Ethernet": {
+      "Ethernet0": {
         "bindings": [
           {
-            "address": "10.0.2.15",
-            "netmask": "255.255.255.0",
-            "network": "10.0.2.0"
+            "address": "10.32.127.212",
+            "netmask": "255.255.240.0",
+            "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::6054:1dfe:23d3:e74c%12",
+            "address": "fe80::a0b5:f374:6703:1ec6%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
-        "dhcp": "10.0.2.2",
-        "ip": "10.0.2.15",
-        "ip6": "fe80::6054:1dfe:23d3:e74c%12",
-        "mac": "08:00:27:A4:27:B4",
+        "dhcp": "10.32.22.10",
+        "ip": "10.32.127.212",
+        "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+        "mac": "00:50:56:A2:D9:94",
         "mtu": 1500,
-        "netmask": "255.255.255.0",
+        "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.0.2.0",
+        "network": "10.32.112.0",
         "network6": "fe80::%12"
-      },
-      "Ethernet 2": {
-        "bindings": [
-          {
-            "address": "10.20.1.5",
-            "netmask": "255.255.255.0",
-            "network": "10.20.1.0"
-          }
-        ],
-        "bindings6": [
-          {
-            "address": "fe80::d925:4b7b:603e:87cd%13",
-            "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%13"
-          }
-        ],
-        "ip": "10.20.1.5",
-        "ip6": "fe80::d925:4b7b:603e:87cd%13",
-        "mac": "08:00:27:8C:BB:02",
-        "mtu": 1500,
-        "netmask": "255.255.255.0",
-        "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.20.1.0",
-        "network6": "fe80::%13"
       }
     },
-    "ip": "10.20.1.5",
-    "ip6": "fe80::d925:4b7b:603e:87cd%13",
-    "mac": "08:00:27:8C:BB:02",
+    "ip": "10.32.127.212",
+    "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+    "mac": "00:50:56:A2:D9:94",
     "mtu": 1500,
-    "netmask": "255.255.255.0",
+    "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
-    "network": "10.20.1.0",
-    "network6": "fe80::%13",
-    "primary": "Ethernet 2"
+    "network": "10.32.112.0",
+    "network6": "fe80::%12",
+    "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -105,26 +118,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\ProgramData\\chocolatey\\bin;C:\\Users\\vagrant\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
-    "physicalcount": 1
+    "physicalcount": 2
   },
+  "productname": "VMware7,1",
+  "puppetversion": "4.4.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.8"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.8",
+  "serialnumber": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 162,
-    "uptime": "0:02 hours"
+    "seconds": 1784,
+    "uptime": "0:29 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "virtualbox"
+  "uptime": "0:29 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 1784,
+  "virtual": "vmware"
 }

--- a/facts/3.1/windows-2012-x86_64.facts
+++ b/facts/3.1/windows-2012-x86_64.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d0 54 b4 68 27 15-5e 55 a0 aa a1 c4 b6 85"
+      "serial_number": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.1.6",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "WX8QEA42SDYVTT6\\Administrator",
   "identity": {
-    "user": "O1JC0NKUU0IWW8R\\Administrator"
+    "user": "WX8QEA42SDYVTT6\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.136",
+  "ipaddress6": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress6_Ethernet0": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress_Ethernet0": "10.32.112.136",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.2",
   "kernelrelease": "6.2.9200",
   "kernelversion": "6.2.9200",
+  "macaddress": "00:50:56:A2:5B:88",
+  "macaddress_Ethernet0": "00:50:56:A2:5B:88",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.27 GiB",
-      "available_bytes": 3514621952,
-      "capacity": "18.15%",
+      "available": "3.33 GiB",
+      "available_bytes": 3574091776,
+      "capacity": "16.77%",
       "total": "4.00 GiB",
       "total_bytes": 4294062080,
-      "used": "743.33 MiB",
-      "used_bytes": 779440128
+      "used": "686.62 MiB",
+      "used_bytes": 719970304
     }
   },
+  "memoryfree": "3.33 GiB",
+  "memoryfree_mb": 3408.51953125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.13671875,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +69,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.115.189",
+            "address": "10.32.112.136",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::b90b:b82d:cd47:12fc%13",
+            "address": "fe80::256a:cde6:f021:6c49%12",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%13"
+            "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.115.189",
-        "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-        "mac": "00:50:56:A2:92:62",
+        "ip": "10.32.112.136",
+        "ip6": "fe80::256a:cde6:f021:6c49%12",
+        "mac": "00:50:56:A2:5B:88",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%13"
+        "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.115.189",
-    "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-    "mac": "00:50:56:A2:92:62",
+    "ip": "10.32.112.136",
+    "ip6": "fe80::256a:cde6:f021:6c49%12",
+    "mac": "00:50:56:A2:5B:88",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%13",
+    "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012",
+  "operatingsystemrelease": "2012",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,31 +118,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.4.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.8"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.8",
+  "serialnumber": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 12,
-    "seconds": 46672,
-    "uptime": "12:57 hours"
+    "hours": 15,
+    "seconds": 54790,
+    "uptime": "15:13 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "15:13 hours",
+  "uptime_days": 0,
+  "uptime_hours": 15,
+  "uptime_seconds": 54790,
+  "virtual": "vmware"
 }

--- a/facts/3.1/windows-2016-x86_64.facts
+++ b/facts/3.1/windows-2016-x86_64.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d8 fb 34 7b b4 e8-dd 91 bd ef cc 32 1e 6c"
+      "serial_number": "VMware-42 22 7d 13 91 74 de e9-6d 4f f8 e5 16 ac c0 3d"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.1.6",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "BDJW8R9XH6J2GEZ\\Administrator",
   "identity": {
-    "user": "IHGAJGT1OU8FTDM\\Administrator"
+    "user": "BDJW8R9XH6J2GEZ\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.121.121",
+  "ipaddress6": "fe80::650e:ed97:4042:6bd2%5",
+  "ipaddress6_Ethernet0": "fe80::650e:ed97:4042:6bd2%5",
+  "ipaddress_Ethernet0": "10.32.121.121",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:23:59",
+  "macaddress_Ethernet0": "00:50:56:A2:23:59",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.03 GiB",
-      "available_bytes": 3250106368,
-      "capacity": "24.31%",
+      "available": "2.98 GiB",
+      "available_bytes": 3198713856,
+      "capacity": "25.51%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "995.59 MiB",
-      "used_bytes": 1043951616
+      "used": "1.02 GiB",
+      "used_bytes": 1095344128
     }
   },
+  "memoryfree": "2.98 GiB",
+  "memoryfree_mb": 3050.53125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%5",
+  "network6_Ethernet0": "fe80::%5",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +69,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.119.232",
+            "address": "10.32.121.121",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::99c3:c512:bd3:5f63%3",
+            "address": "fe80::650e:ed97:4042:6bd2%5",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%3"
+            "network": "fe80::%5"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.119.232",
-        "ip6": "fe80::99c3:c512:bd3:5f63%3",
-        "mac": "00:50:56:A2:68:15",
+        "ip": "10.32.121.121",
+        "ip6": "fe80::650e:ed97:4042:6bd2%5",
+        "mac": "00:50:56:A2:23:59",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%3"
+        "network6": "fe80::%5"
       }
     },
-    "ip": "10.32.119.232",
-    "ip6": "fe80::99c3:c512:bd3:5f63%3",
-    "mac": "00:50:56:A2:68:15",
+    "ip": "10.32.121.121",
+    "ip6": "fe80::650e:ed97:4042:6bd2%5",
+    "mac": "00:50:56:A2:23:59",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%3",
+    "network6": "fe80::%5",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10.0.14393",
+  "operatingsystemrelease": "10.0.14393",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,7 +118,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -93,21 +133,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.4.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.8"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.8",
+  "serialnumber": "VMware-42 22 7d 13 91 74 de e9-6d 4f f8 e5 16 ac c0 3d",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 1,
-    "seconds": 4842,
-    "uptime": "1:20 hours"
+    "hours": 16,
+    "seconds": 60245,
+    "uptime": "16:44 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "uptime": "16:44 hours",
+  "uptime_days": 0,
+  "uptime_hours": 16,
+  "uptime_seconds": 60245,
+  "virtual": "vmware"
 }

--- a/facts/3.1/windows-7-x86_64.facts
+++ b/facts/3.1/windows-7-x86_64.facts
@@ -1,97 +1,110 @@
 {
+  "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
-    "manufacturer": "innotek GmbH",
+    "manufacturer": "VMware, Inc.",
     "product": {
-      "name": "VirtualBox",
-      "serial_number": "0"
+      "name": "VMware7,1",
+      "serial_number": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
-  "facterversion": "3.1.5",
+  "facterversion": "3.1.6",
   "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "N6IFGFZXW976ITI\\Administrator",
   "identity": {
-    "user": "FOO\\vagrant"
+    "user": "N6IFGFZXW976ITI\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.90",
+  "ipaddress6": "fe80::2121:2899:8986:e379%11",
+  "ipaddress6_Local Area Connection": "fe80::2121:2899:8986:e379%11",
+  "ipaddress_Local Area Connection": "10.32.126.90",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
-  "kernelrelease": "6.1.7600",
-  "kernelversion": "6.1.7600",
+  "kernelrelease": "6.1.7601",
+  "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:78:83",
+  "macaddress_Local Area Connection": "00:50:56:A2:78:83",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "321.22 MiB",
-      "available_bytes": 336826368,
-      "capacity": "68.62%",
-      "total": "1023.55 MiB",
-      "total_bytes": 1073274880,
-      "used": "702.33 MiB",
-      "used_bytes": 736448512
+      "available": "3.02 GiB",
+      "available_bytes": 3247546368,
+      "capacity": "24.37%",
+      "total": "4.00 GiB",
+      "total_bytes": 4294066176,
+      "used": "998.04 MiB",
+      "used_bytes": 1046519808
     }
   },
+  "memoryfree": "3.02 GiB",
+  "memoryfree_mb": 3097.1015625,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
-    "fqdn": "foo",
+    "dhcp": "10.32.22.10",
+    "domain": "example.com",
+    "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.0.2.15",
-            "netmask": "255.255.255.0",
-            "network": "10.0.2.0"
+            "address": "10.32.126.90",
+            "netmask": "255.255.240.0",
+            "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::700d:3fab:1d54:dc0d%11",
+            "address": "fe80::2121:2899:8986:e379%11",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%11"
           }
         ],
-        "dhcp": "10.0.2.2",
-        "ip": "10.0.2.15",
-        "ip6": "fe80::700d:3fab:1d54:dc0d%11",
-        "mac": "08:00:27:67:C8:1B",
+        "dhcp": "10.32.22.10",
+        "ip": "10.32.126.90",
+        "ip6": "fe80::2121:2899:8986:e379%11",
+        "mac": "00:50:56:A2:78:83",
         "mtu": 1500,
-        "netmask": "255.255.255.0",
+        "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.0.2.0",
+        "network": "10.32.112.0",
         "network6": "fe80::%11"
-      },
-      "Local Area Connection 3": {
-        "bindings": [
-          {
-            "address": "10.20.1.5",
-            "netmask": "255.255.255.0",
-            "network": "10.20.1.0"
-          }
-        ],
-        "bindings6": [
-          {
-            "address": "fe80::15ec:2eb0:42ca:d968%13",
-            "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%13"
-          }
-        ],
-        "ip": "10.20.1.5",
-        "ip6": "fe80::15ec:2eb0:42ca:d968%13",
-        "mac": "08:00:27:81:BB:CB",
-        "mtu": 1500,
-        "netmask": "255.255.255.0",
-        "netmask6": "ffff:ffff:ffff:ffff::",
-        "network": "10.20.1.0",
-        "network6": "fe80::%13"
       }
     },
-    "ip": "10.20.1.5",
-    "ip6": "fe80::15ec:2eb0:42ca:d968%13",
-    "mac": "08:00:27:81:BB:CB",
+    "ip": "10.32.126.90",
+    "ip6": "fe80::2121:2899:8986:e379%11",
+    "mac": "00:50:56:A2:78:83",
     "mtu": 1500,
-    "netmask": "255.255.255.0",
+    "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
-    "network": "10.20.1.0",
-    "network6": "fe80::%13",
-    "primary": "Local Area Connection 3"
+    "network": "10.32.112.0",
+    "network6": "fe80::%11",
+    "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "7",
+  "operatingsystemrelease": "7",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -105,26 +118,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Program Files (x86)\\Git\\bin; ",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
-    "count": 1,
+    "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
-    "physicalcount": 1
+    "physicalcount": 2
   },
+  "productname": "VMware7,1",
+  "puppetversion": "4.4.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.8"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.8",
+  "serialnumber": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 177,
-    "uptime": "0:02 hours"
+    "hours": 8,
+    "seconds": 29481,
+    "uptime": "8:11 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "virtualbox"
+  "uptime": "8:11 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29481,
+  "virtual": "vmware"
 }

--- a/facts/3.1/windows-8.1-x86_64.facts
+++ b/facts/3.1/windows-8.1-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 0f 99 71 37 c9 34 5c-60 e2 5f ad 59 28 d7 53"
+      "serial_number": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.1.6",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "B5GMZC25YP3WRFT\\Administrator",
   "identity": {
-    "user": "TGPX4C0ZOVOW6AL\\Administrator"
+    "user": "B5GMZC25YP3WRFT\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.84",
+  "ipaddress6": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress6_Ethernet0": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress_Ethernet0": "10.32.125.84",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:FD:34",
+  "macaddress_Ethernet0": "00:50:56:A2:FD:34",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.60 GiB",
-      "available_bytes": 2788700160,
-      "capacity": "35.06%",
+      "available": "2.49 GiB",
+      "available_bytes": 2672300032,
+      "capacity": "37.77%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.40 GiB",
-      "used_bytes": 1505366016
+      "used": "1.51 GiB",
+      "used_bytes": 1621766144
     }
   },
+  "memoryfree": "2.49 GiB",
+  "memoryfree_mb": 2548.50390625,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
-    "dhcp": "10.32.22.9",
+    "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
@@ -37,22 +69,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.126.10",
+            "address": "10.32.125.84",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::d9b6:d8a2:98e1:bcf0%3",
+            "address": "fe80::e490:85dc:9a71:4d9e%3",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%3"
           }
         ],
-        "dhcp": "10.32.22.9",
-        "ip": "10.32.126.10",
-        "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-        "mac": "00:50:56:8F:42:E3",
+        "dhcp": "10.32.22.10",
+        "ip": "10.32.125.84",
+        "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+        "mac": "00:50:56:A2:FD:34",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -60,9 +92,9 @@
         "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.126.10",
-    "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-    "mac": "00:50:56:8F:42:E3",
+    "ip": "10.32.125.84",
+    "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+    "mac": "00:50:56:A2:FD:34",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -70,6 +102,9 @@
     "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "8.1",
+  "operatingsystemrelease": "8.1",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,7 +118,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -93,21 +133,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.4.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.8"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.8",
+  "serialnumber": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 11,
-    "hours": 275,
-    "seconds": 993059,
-    "uptime": "11 days"
+    "days": 0,
+    "hours": 18,
+    "seconds": 66721,
+    "uptime": "18:32 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "18:32 hours",
+  "uptime_days": 0,
+  "uptime_hours": 18,
+  "uptime_seconds": 66721,
+  "virtual": "vmware"
 }

--- a/facts/3.3/windows-10-i386.facts
+++ b/facts/3.3/windows-10-i386.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x86",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 ca fe f0 e7 64 ba-7e c1 ac 81 ec 79 2a c9"
+      "serial_number": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.3.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "i686",
+  "hostname": "foo",
+  "id": "CAYR11ES3BMJ6UG\\Administrator",
   "identity": {
-    "user": "CD9O9NMEXAPI3GF\\Administrator"
+    "user": "CAYR11ES3BMJ6UG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.121.213",
+  "ipaddress6": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress6_Ethernet0": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress_Ethernet0": "10.32.121.213",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:72:55",
+  "macaddress_Ethernet0": "00:50:56:A2:72:55",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.01 GiB",
-      "available_bytes": 2153246720,
-      "capacity": "33.14%",
+      "available": "1.94 GiB",
+      "available_bytes": 2086633472,
+      "capacity": "35.20%",
       "total": "3.00 GiB",
       "total_bytes": 3220324352,
-      "used": "1017.64 MiB",
-      "used_bytes": 1067077632
+      "used": "1.06 GiB",
+      "used_bytes": 1133690880
     }
   },
+  "memoryfree": "1.94 GiB",
+  "memoryfree_mb": 1989.96875,
+  "memorysize": "3.00 GiB",
+  "memorysize_mb": 3071.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +69,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.120.121",
+            "address": "10.32.121.213",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::45d7:5af5:8f53:8392%5",
+            "address": "fe80::4dab:3df1:6f45:ee04%3",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%5"
+            "network": "fe80::%3"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.120.121",
-        "ip6": "fe80::45d7:5af5:8f53:8392%5",
-        "mac": "00:50:56:A2:D4:F1",
+        "ip": "10.32.121.213",
+        "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+        "mac": "00:50:56:A2:72:55",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%5"
+        "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.120.121",
-    "ip6": "fe80::45d7:5af5:8f53:8392%5",
-    "mac": "00:50:56:A2:D4:F1",
+    "ip": "10.32.121.213",
+    "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+    "mac": "00:50:56:A2:72:55",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%5",
+    "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10.0.14393",
+  "operatingsystemrelease": "10.0.14393",
   "os": {
     "architecture": "x86",
     "family": "windows",
@@ -83,7 +118,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -93,21 +133,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.5.3",
   "ruby": {
     "platform": "i386-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "i386-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 1025,
-    "uptime": "0:17 hours"
+    "hours": 6,
+    "seconds": 23347,
+    "uptime": "6:29 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:29 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 23347,
+  "virtual": "vmware"
 }

--- a/facts/3.3/windows-10-x86_64.facts
+++ b/facts/3.3/windows-10-x86_64.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 b9 12 ec 3b 6e ab-61 61 29 cf f4 72 99 c3"
+      "serial_number": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.3.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "V46YN43Q8ZY3NYG\\Administrator",
   "identity": {
-    "user": "PQX8SDC5TGXO8LI\\Administrator"
+    "user": "V46YN43Q8ZY3NYG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.130",
+  "ipaddress6": "fe80::e110:a74a:480:4409%4",
+  "ipaddress6_Ethernet0": "fe80::e110:a74a:480:4409%4",
+  "ipaddress_Ethernet0": "10.32.112.130",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:BB:13",
+  "macaddress_Ethernet0": "00:50:56:A2:BB:13",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.82 GiB",
-      "available_bytes": 3022860288,
-      "capacity": "29.60%",
+      "available": "2.64 GiB",
+      "available_bytes": 2829869056,
+      "capacity": "34.10%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "1.18 GiB",
-      "used_bytes": 1271197696
+      "used": "1.36 GiB",
+      "used_bytes": 1464188928
     }
   },
+  "memoryfree": "2.64 GiB",
+  "memoryfree_mb": 2698.7734375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%4",
+  "network6_Ethernet0": "fe80::%4",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +69,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.113.158",
+            "address": "10.32.112.130",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::753c:44f6:3bb1:cb0c%2",
+            "address": "fe80::e110:a74a:480:4409%4",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%2"
+            "network": "fe80::%4"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.158",
-        "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-        "mac": "00:50:56:A2:B1:5B",
+        "ip": "10.32.112.130",
+        "ip6": "fe80::e110:a74a:480:4409%4",
+        "mac": "00:50:56:A2:BB:13",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%2"
+        "network6": "fe80::%4"
       }
     },
-    "ip": "10.32.113.158",
-    "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-    "mac": "00:50:56:A2:B1:5B",
+    "ip": "10.32.112.130",
+    "ip6": "fe80::e110:a74a:480:4409%4",
+    "mac": "00:50:56:A2:BB:13",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%2",
+    "network6": "fe80::%4",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10.0.14393",
+  "operatingsystemrelease": "10.0.14393",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,31 +118,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.5.3",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 16,
-    "seconds": 57715,
-    "uptime": "16:01 hours"
+    "hours": 6,
+    "seconds": 23164,
+    "uptime": "6:26 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:26 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 23164,
+  "virtual": "vmware"
 }

--- a/facts/3.3/windows-2008 r2-x86_64.facts
+++ b/facts/3.3/windows-2008 r2-x86_64.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 6f a5 43 75 12 ae-15 76 ec 76 47 5d 25 9a"
+      "serial_number": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.3.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "RJ2WFCMG7UF17CW\\Administrator",
   "identity": {
-    "user": "HKB7CU8PWYEHS3A\\Administrator"
+    "user": "RJ2WFCMG7UF17CW\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.127.75",
+  "ipaddress6": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress6_Local Area Connection": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress_Local Area Connection": "10.32.127.75",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:06:09",
+  "macaddress_Local Area Connection": "00:50:56:A2:06:09",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.91 GiB",
-      "available_bytes": 3126923264,
-      "capacity": "27.18%",
+      "available": "3.03 GiB",
+      "available_bytes": 3249676288,
+      "capacity": "24.32%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.09 GiB",
-      "used_bytes": 1167142912
+      "used": "996.01 MiB",
+      "used_bytes": 1044389888
     }
   },
+  "memoryfree": "3.03 GiB",
+  "memoryfree_mb": 3099.1328125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +69,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.116.113",
+            "address": "10.32.127.75",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::60bc:b13:61bf:9110%12",
+            "address": "fe80::80be:a6bc:1766:4c99%11",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%12"
+            "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.116.113",
-        "ip6": "fe80::60bc:b13:61bf:9110%12",
-        "mac": "00:50:56:A2:C2:80",
+        "ip": "10.32.127.75",
+        "ip6": "fe80::80be:a6bc:1766:4c99%11",
+        "mac": "00:50:56:A2:06:09",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%12"
+        "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.116.113",
-    "ip6": "fe80::60bc:b13:61bf:9110%12",
-    "mac": "00:50:56:A2:C2:80",
+    "ip": "10.32.127.75",
+    "ip6": "fe80::80be:a6bc:1766:4c99%11",
+    "mac": "00:50:56:A2:06:09",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%12",
+    "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008 R2",
+  "operatingsystemrelease": "2008 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,7 +118,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -93,21 +133,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.5.3",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 499,
-    "uptime": "0:08 hours"
+    "hours": 16,
+    "seconds": 60412,
+    "uptime": "16:46 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "16:46 hours",
+  "uptime_days": 0,
+  "uptime_hours": 16,
+  "uptime_seconds": 60412,
+  "virtual": "vmware"
 }

--- a/facts/3.3/windows-2008-x86_64.facts
+++ b/facts/3.3/windows-2008-x86_64.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "Phoenix Technologies LTD",
     "product": {
       "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 3f 06 9e 43 30 eb-b3 f4 58 de 6a 3e e5 9f"
+      "serial_number": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.3.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "QFMZ60DYQGU893J\\Administrator",
   "identity": {
-    "user": "D5NOW95YYUDLWEV\\Administrator"
+    "user": "QFMZ60DYQGU893J\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.95",
+  "ipaddress6": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress6_Local Area Connection": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress_Local Area Connection": "10.32.126.95",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.0",
   "kernelrelease": "6.0.6002",
   "kernelversion": "6.0.6002",
+  "macaddress": "00:50:56:A2:E0:07",
+  "macaddress_Local Area Connection": "00:50:56:A2:E0:07",
+  "manufacturer": "Phoenix Technologies LTD",
   "memory": {
     "system": {
-      "available": "3.14 GiB",
-      "available_bytes": 3373146112,
-      "capacity": "21.43%",
+      "available": "3.17 GiB",
+      "available_bytes": 3402412032,
+      "capacity": "20.75%",
       "total": "4.00 GiB",
       "total_bytes": 4293357568,
-      "used": "877.58 MiB",
-      "used_bytes": 920211456
+      "used": "849.67 MiB",
+      "used_bytes": 890945536
     }
   },
+  "memoryfree": "3.17 GiB",
+  "memoryfree_mb": 3244.79296875,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4094.46484375,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%10",
+  "network6_Local Area Connection": "fe80::%10",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +69,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.117.107",
+            "address": "10.32.126.95",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::e9c8:8f06:477c:99fa%11",
+            "address": "fe80::dd24:f5a9:347b:c256%10",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%11"
+            "network": "fe80::%10"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.117.107",
-        "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-        "mac": "00:50:56:A2:B1:DA",
+        "ip": "10.32.126.95",
+        "ip6": "fe80::dd24:f5a9:347b:c256%10",
+        "mac": "00:50:56:A2:E0:07",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%11"
+        "network6": "fe80::%10"
       }
     },
-    "ip": "10.32.117.107",
-    "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-    "mac": "00:50:56:A2:B1:DA",
+    "ip": "10.32.126.95",
+    "ip6": "fe80::dd24:f5a9:347b:c256%10",
+    "mac": "00:50:56:A2:E0:07",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%11",
+    "network6": "fe80::%10",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008",
+  "operatingsystemrelease": "2008",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,31 +118,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware Virtual Platform",
   "puppetversion": "4.5.3",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 15,
-    "seconds": 55039,
-    "uptime": "15:17 hours"
+    "hours": 14,
+    "seconds": 50680,
+    "uptime": "14:04 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "14:04 hours",
+  "uptime_days": 0,
+  "uptime_hours": 14,
+  "uptime_seconds": 50680,
+  "virtual": "vmware"
 }

--- a/facts/3.3/windows-2012 r2-core-x86_64.facts
+++ b/facts/3.3/windows-2012 r2-core-x86_64.facts
@@ -1,58 +1,90 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
-    "manufacturer": "Phoenix Technologies LTD",
+    "manufacturer": "VMware, Inc.",
     "product": {
-      "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 91 42 5a d1 7a 50-73 d9 8a 73 2a ba e5 d9"
+      "name": "VMware7,1",
+      "serial_number": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.3.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "G0ZBZXENEIL32X5\\Administrator",
   "identity": {
-    "user": "GHWYJ7383D7T8XY\\cyg_server"
+    "user": "G0ZBZXENEIL32X5\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.117.89",
+  "ipaddress6": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress6_Ethernet0": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress_Ethernet0": "10.32.117.89",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:72:05",
+  "macaddress_Ethernet0": "00:50:56:A2:72:05",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.09 GiB",
-      "available_bytes": 3315433472,
-      "capacity": "22.80%",
-      "total": "4.00 GiB",
-      "total_bytes": 4294496256,
-      "used": "933.71 MiB",
-      "used_bytes": 979062784
+      "available": "5.36 GiB",
+      "available_bytes": 5758353408,
+      "capacity": "10.61%",
+      "total": "6.00 GiB",
+      "total_bytes": 6441549824,
+      "used": "651.55 MiB",
+      "used_bytes": 683196416
     }
   },
+  "memoryfree": "5.36 GiB",
+  "memoryfree_mb": 5491.59375,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
-      "Ethernet": {
+      "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.114.127",
+            "address": "10.32.117.89",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::fd0d:3323:1bb4:680d%12",
+            "address": "fe80::71c4:5555:d38:94fa%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.114.127",
-        "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-        "mac": "00:50:56:A2:34:6A",
+        "ip": "10.32.117.89",
+        "ip6": "fe80::71c4:5555:d38:94fa%12",
+        "mac": "00:50:56:A2:72:05",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -60,16 +92,19 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.114.127",
-    "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-    "mac": "00:50:56:A2:34:6A",
+    "ip": "10.32.117.89",
+    "ip6": "fe80::71c4:5555:d38:94fa%12",
+    "mac": "00:50:56:A2:72:05",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
     "network6": "fe80::%12",
-    "primary": "Ethernet"
+    "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,7 +118,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\pstools;C:\\cygwin64\\bin",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -93,21 +133,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.5.3",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 0,
-    "hours": 11,
-    "seconds": 41578,
-    "uptime": "11:32 hours"
+    "days": 1,
+    "hours": 24,
+    "seconds": 86962,
+    "uptime": "1 day"
   },
-  "timezone": "Pacific Daylight Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "timezone": "Coordinated Universal Time",
+  "uptime": "1 day",
+  "uptime_days": 1,
+  "uptime_hours": 24,
+  "uptime_seconds": 86962,
+  "virtual": "vmware"
 }

--- a/facts/3.3/windows-2012 r2-x86_64.facts
+++ b/facts/3.3/windows-2012 r2-x86_64.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 f5 c4 62 f1 23 8a-45 87 85 c8 cc 40 99 c5"
+      "serial_number": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.3.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GTT427VBINBGPOL\\Administrator",
   "identity": {
-    "user": "QYK15CXKD67BH65\\Administrator"
+    "user": "GTT427VBINBGPOL\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.127.212",
+  "ipaddress6": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress6_Ethernet0": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress_Ethernet0": "10.32.127.212",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:D9:94",
+  "macaddress_Ethernet0": "00:50:56:A2:D9:94",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "5.22 GiB",
-      "available_bytes": 5610233856,
-      "capacity": "12.91%",
+      "available": "5.27 GiB",
+      "available_bytes": 5659611136,
+      "capacity": "12.14%",
       "total": "6.00 GiB",
       "total_bytes": 6441549824,
-      "used": "792.80 MiB",
-      "used_bytes": 831315968
+      "used": "745.71 MiB",
+      "used_bytes": 781938688
     }
   },
+  "memoryfree": "5.27 GiB",
+  "memoryfree_mb": 5397.42578125,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,22 +69,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.113.108",
+            "address": "10.32.127.212",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::d432:9626:e5c4:73fa%12",
+            "address": "fe80::a0b5:f374:6703:1ec6%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.108",
-        "ip6": "fe80::d432:9626:e5c4:73fa%12",
-        "mac": "00:50:56:A2:D5:08",
+        "ip": "10.32.127.212",
+        "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+        "mac": "00:50:56:A2:D9:94",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -60,9 +92,9 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.113.108",
-    "ip6": "fe80::d432:9626:e5c4:73fa%12",
-    "mac": "00:50:56:A2:D5:08",
+    "ip": "10.32.127.212",
+    "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+    "mac": "00:50:56:A2:D9:94",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -70,6 +102,9 @@
     "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,7 +118,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -93,21 +133,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.5.3",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 3,
-    "seconds": 12131,
-    "uptime": "3:22 hours"
+    "hours": 0,
+    "seconds": 1747,
+    "uptime": "0:29 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "0:29 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 1747,
+  "virtual": "vmware"
 }

--- a/facts/3.3/windows-2012-x86_64.facts
+++ b/facts/3.3/windows-2012-x86_64.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d0 54 b4 68 27 15-5e 55 a0 aa a1 c4 b6 85"
+      "serial_number": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.3.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "WX8QEA42SDYVTT6\\Administrator",
   "identity": {
-    "user": "O1JC0NKUU0IWW8R\\Administrator"
+    "user": "WX8QEA42SDYVTT6\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.136",
+  "ipaddress6": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress6_Ethernet0": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress_Ethernet0": "10.32.112.136",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.2",
   "kernelrelease": "6.2.9200",
   "kernelversion": "6.2.9200",
+  "macaddress": "00:50:56:A2:5B:88",
+  "macaddress_Ethernet0": "00:50:56:A2:5B:88",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.23 GiB",
-      "available_bytes": 3472740352,
-      "capacity": "19.13%",
+      "available": "3.27 GiB",
+      "available_bytes": 3507662848,
+      "capacity": "18.31%",
       "total": "4.00 GiB",
       "total_bytes": 4294062080,
-      "used": "783.27 MiB",
-      "used_bytes": 821321728
+      "used": "749.97 MiB",
+      "used_bytes": 786399232
     }
   },
+  "memoryfree": "3.27 GiB",
+  "memoryfree_mb": 3345.16796875,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.13671875,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +69,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.115.189",
+            "address": "10.32.112.136",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::b90b:b82d:cd47:12fc%13",
+            "address": "fe80::256a:cde6:f021:6c49%12",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%13"
+            "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.115.189",
-        "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-        "mac": "00:50:56:A2:92:62",
+        "ip": "10.32.112.136",
+        "ip6": "fe80::256a:cde6:f021:6c49%12",
+        "mac": "00:50:56:A2:5B:88",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%13"
+        "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.115.189",
-    "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-    "mac": "00:50:56:A2:92:62",
+    "ip": "10.32.112.136",
+    "ip6": "fe80::256a:cde6:f021:6c49%12",
+    "mac": "00:50:56:A2:5B:88",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%13",
+    "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012",
+  "operatingsystemrelease": "2012",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,31 +118,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.5.3",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 12,
-    "seconds": 46632,
-    "uptime": "12:57 hours"
+    "hours": 15,
+    "seconds": 54750,
+    "uptime": "15:12 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "15:12 hours",
+  "uptime_days": 0,
+  "uptime_hours": 15,
+  "uptime_seconds": 54750,
+  "virtual": "vmware"
 }

--- a/facts/3.3/windows-2016-x86_64.facts
+++ b/facts/3.3/windows-2016-x86_64.facts
@@ -1,33 +1,64 @@
 {
-  "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d8 fb 34 7b b4 e8-dd 91 bd ef cc 32 1e 6c"
+      "serial_number": "VMware-42 22 7d 13 91 74 de e9-6d 4f f8 e5 16 ac c0 3d"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.3.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "BDJW8R9XH6J2GEZ\\Administrator",
   "identity": {
-    "user": "IHGAJGT1OU8FTDM\\Administrator"
+    "user": "BDJW8R9XH6J2GEZ\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.121.121",
+  "ipaddress6": "fe80::650e:ed97:4042:6bd2%5",
+  "ipaddress6_Ethernet0": "fe80::650e:ed97:4042:6bd2%5",
+  "ipaddress_Ethernet0": "10.32.121.121",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:23:59",
+  "macaddress_Ethernet0": "00:50:56:A2:23:59",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
       "available": "2.99 GiB",
-      "available_bytes": 3212234752,
-      "capacity": "25.19%",
+      "available_bytes": 3207188480,
+      "capacity": "25.31%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
       "used": "1.01 GiB",
-      "used_bytes": 1081823232
+      "used_bytes": 1086869504
     }
   },
+  "memoryfree": "2.99 GiB",
+  "memoryfree_mb": 3058.61328125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%5",
+  "network6_Ethernet0": "fe80::%5",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +68,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.119.232",
+            "address": "10.32.121.121",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::99c3:c512:bd3:5f63%3",
+            "address": "fe80::650e:ed97:4042:6bd2%5",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%3"
+            "network": "fe80::%5"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.119.232",
-        "ip6": "fe80::99c3:c512:bd3:5f63%3",
-        "mac": "00:50:56:A2:68:15",
+        "ip": "10.32.121.121",
+        "ip6": "fe80::650e:ed97:4042:6bd2%5",
+        "mac": "00:50:56:A2:23:59",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%3"
+        "network6": "fe80::%5"
       }
     },
-    "ip": "10.32.119.232",
-    "ip6": "fe80::99c3:c512:bd3:5f63%3",
-    "mac": "00:50:56:A2:68:15",
+    "ip": "10.32.121.121",
+    "ip6": "fe80::650e:ed97:4042:6bd2%5",
+    "mac": "00:50:56:A2:23:59",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%3",
+    "network6": "fe80::%5",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10.0.14393",
+  "operatingsystemrelease": "10.0.14393",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,7 +117,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -93,21 +132,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.5.3",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 7d 13 91 74 de e9-6d 4f f8 e5 16 ac c0 3d",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 1,
-    "seconds": 4795,
-    "uptime": "1:19 hours"
+    "hours": 16,
+    "seconds": 60197,
+    "uptime": "16:43 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "uptime": "16:43 hours",
+  "uptime_days": 0,
+  "uptime_hours": 16,
+  "uptime_seconds": 60197,
+  "virtual": "vmware"
 }

--- a/facts/3.3/windows-7-x86_64.facts
+++ b/facts/3.3/windows-7-x86_64.facts
@@ -1,33 +1,65 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 a6 6f 63 84 0d 53-07 bc 72 79 02 59 33 7a"
+      "serial_number": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.3.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "N6IFGFZXW976ITI\\Administrator",
   "identity": {
-    "user": "G089LVS4X1ERMNM\\Administrator"
+    "user": "N6IFGFZXW976ITI\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.90",
+  "ipaddress6": "fe80::2121:2899:8986:e379%11",
+  "ipaddress6_Local Area Connection": "fe80::2121:2899:8986:e379%11",
+  "ipaddress_Local Area Connection": "10.32.126.90",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:78:83",
+  "macaddress_Local Area Connection": "00:50:56:A2:78:83",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
       "available": "3.01 GiB",
-      "available_bytes": 3237273600,
-      "capacity": "24.61%",
+      "available_bytes": 3231936512,
+      "capacity": "24.73%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1007.84 MiB",
-      "used_bytes": 1056792576
+      "used": "1012.93 MiB",
+      "used_bytes": 1062129664
     }
   },
+  "memoryfree": "3.01 GiB",
+  "memoryfree_mb": 3082.21484375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -37,39 +69,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.126.73",
+            "address": "10.32.126.90",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::b4bd:32dd:a5c:f8a%12",
+            "address": "fe80::2121:2899:8986:e379%11",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%12"
+            "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.126.73",
-        "ip6": "fe80::b4bd:32dd:a5c:f8a%12",
-        "mac": "00:50:56:A2:EF:51",
+        "ip": "10.32.126.90",
+        "ip6": "fe80::2121:2899:8986:e379%11",
+        "mac": "00:50:56:A2:78:83",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%12"
+        "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.126.73",
-    "ip6": "fe80::b4bd:32dd:a5c:f8a%12",
-    "mac": "00:50:56:A2:EF:51",
+    "ip": "10.32.126.90",
+    "ip6": "fe80::2121:2899:8986:e379%11",
+    "mac": "00:50:56:A2:78:83",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%12",
+    "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "7",
+  "operatingsystemrelease": "7",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,7 +118,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -93,21 +133,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.5.3",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 16,
-    "seconds": 58995,
-    "uptime": "16:23 hours"
+    "hours": 8,
+    "seconds": 29429,
+    "uptime": "8:10 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "8:10 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29429,
+  "virtual": "vmware"
 }

--- a/facts/3.3/windows-8.1-x86_64.facts
+++ b/facts/3.3/windows-8.1-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 0f 99 71 37 c9 34 5c-60 e2 5f ad 59 28 d7 53"
+      "serial_number": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.3.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "B5GMZC25YP3WRFT\\Administrator",
   "identity": {
-    "user": "TGPX4C0ZOVOW6AL\\Administrator"
+    "user": "B5GMZC25YP3WRFT\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.84",
+  "ipaddress6": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress6_Ethernet0": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress_Ethernet0": "10.32.125.84",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:FD:34",
+  "macaddress_Ethernet0": "00:50:56:A2:FD:34",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.59 GiB",
-      "available_bytes": 2784649216,
-      "capacity": "35.15%",
+      "available": "2.49 GiB",
+      "available_bytes": 2672676864,
+      "capacity": "37.76%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.41 GiB",
-      "used_bytes": 1509416960
+      "used": "1.51 GiB",
+      "used_bytes": 1621389312
     }
   },
+  "memoryfree": "2.49 GiB",
+  "memoryfree_mb": 2548.86328125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
-    "dhcp": "10.32.22.9",
+    "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
@@ -37,22 +69,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.126.10",
+            "address": "10.32.125.84",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::d9b6:d8a2:98e1:bcf0%3",
+            "address": "fe80::e490:85dc:9a71:4d9e%3",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%3"
           }
         ],
-        "dhcp": "10.32.22.9",
-        "ip": "10.32.126.10",
-        "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-        "mac": "00:50:56:8F:42:E3",
+        "dhcp": "10.32.22.10",
+        "ip": "10.32.125.84",
+        "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+        "mac": "00:50:56:A2:FD:34",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -60,9 +92,9 @@
         "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.126.10",
-    "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-    "mac": "00:50:56:8F:42:E3",
+    "ip": "10.32.125.84",
+    "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+    "mac": "00:50:56:A2:FD:34",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -70,6 +102,9 @@
     "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "8.1",
+  "operatingsystemrelease": "8.1",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -83,7 +118,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -93,21 +133,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.5.3",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 11,
-    "hours": 275,
-    "seconds": 993008,
-    "uptime": "11 days"
+    "days": 0,
+    "hours": 18,
+    "seconds": 66676,
+    "uptime": "18:31 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "18:31 hours",
+  "uptime_days": 0,
+  "uptime_hours": 18,
+  "uptime_seconds": 66676,
+  "virtual": "vmware"
 }

--- a/facts/3.4/windows-10-i386.facts
+++ b/facts/3.4/windows-10-i386.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.7.2",
+  "architecture": "x86",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 ca fe f0 e7 64 ba-7e c1 ac 81 ec 79 2a c9"
+      "serial_number": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.4.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "i686",
+  "hostname": "foo",
+  "id": "CAYR11ES3BMJ6UG\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "CD9O9NMEXAPI3GF\\Administrator"
+    "user": "CAYR11ES3BMJ6UG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.121.213",
+  "ipaddress6": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress6_Ethernet0": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress_Ethernet0": "10.32.121.213",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:72:55",
+  "macaddress_Ethernet0": "00:50:56:A2:72:55",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "1.94 GiB",
-      "available_bytes": 2078613504,
-      "capacity": "35.45%",
+      "available": "1.86 GiB",
+      "available_bytes": 1998852096,
+      "capacity": "37.93%",
       "total": "3.00 GiB",
       "total_bytes": 3220324352,
-      "used": "1.06 GiB",
-      "used_bytes": 1141710848
+      "used": "1.14 GiB",
+      "used_bytes": 1221472256
     }
   },
+  "memoryfree": "1.86 GiB",
+  "memoryfree_mb": 1906.25390625,
+  "memorysize": "3.00 GiB",
+  "memorysize_mb": 3071.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.120.121",
+            "address": "10.32.121.213",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::45d7:5af5:8f53:8392%5",
+            "address": "fe80::4dab:3df1:6f45:ee04%3",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%5"
+            "network": "fe80::%3"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.120.121",
-        "ip6": "fe80::45d7:5af5:8f53:8392%5",
-        "mac": "00:50:56:A2:D4:F1",
+        "ip": "10.32.121.213",
+        "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+        "mac": "00:50:56:A2:72:55",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%5"
+        "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.120.121",
-    "ip6": "fe80::45d7:5af5:8f53:8392%5",
-    "mac": "00:50:56:A2:D4:F1",
+    "ip": "10.32.121.213",
+    "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+    "mac": "00:50:56:A2:72:55",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%5",
+    "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10",
+  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x86",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.7.1",
   "ruby": {
     "platform": "i386-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "i386-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 962,
-    "uptime": "0:16 hours"
+    "hours": 6,
+    "seconds": 23286,
+    "uptime": "6:28 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:28 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 23286,
+  "virtual": "vmware"
 }

--- a/facts/3.4/windows-10-x86_64.facts
+++ b/facts/3.4/windows-10-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.7.2",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 b9 12 ec 3b 6e ab-61 61 29 cf f4 72 99 c3"
+      "serial_number": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.4.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "V46YN43Q8ZY3NYG\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "PQX8SDC5TGXO8LI\\Administrator"
+    "user": "V46YN43Q8ZY3NYG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.130",
+  "ipaddress6": "fe80::e110:a74a:480:4409%4",
+  "ipaddress6_Ethernet0": "fe80::e110:a74a:480:4409%4",
+  "ipaddress_Ethernet0": "10.32.112.130",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:BB:13",
+  "macaddress_Ethernet0": "00:50:56:A2:BB:13",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.71 GiB",
-      "available_bytes": 2905133056,
-      "capacity": "32.35%",
+      "available": "2.64 GiB",
+      "available_bytes": 2830430208,
+      "capacity": "34.08%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "1.29 GiB",
-      "used_bytes": 1388924928
+      "used": "1.36 GiB",
+      "used_bytes": 1463627776
     }
   },
+  "memoryfree": "2.64 GiB",
+  "memoryfree_mb": 2699.30859375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%4",
+  "network6_Ethernet0": "fe80::%4",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.113.158",
+            "address": "10.32.112.130",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::753c:44f6:3bb1:cb0c%2",
+            "address": "fe80::e110:a74a:480:4409%4",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%2"
+            "network": "fe80::%4"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.158",
-        "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-        "mac": "00:50:56:A2:B1:5B",
+        "ip": "10.32.112.130",
+        "ip6": "fe80::e110:a74a:480:4409%4",
+        "mac": "00:50:56:A2:BB:13",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%2"
+        "network6": "fe80::%4"
       }
     },
-    "ip": "10.32.113.158",
-    "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-    "mac": "00:50:56:A2:B1:5B",
+    "ip": "10.32.112.130",
+    "ip6": "fe80::e110:a74a:480:4409%4",
+    "mac": "00:50:56:A2:BB:13",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%2",
+    "network6": "fe80::%4",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10",
+  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.7.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 16,
-    "seconds": 57659,
-    "uptime": "16:00 hours"
+    "hours": 6,
+    "seconds": 23106,
+    "uptime": "6:25 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:25 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 23106,
+  "virtual": "vmware"
 }

--- a/facts/3.4/windows-2008 r2-x86_64.facts
+++ b/facts/3.4/windows-2008 r2-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.7.2",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 6f a5 43 75 12 ae-15 76 ec 76 47 5d 25 9a"
+      "serial_number": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.4.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "RJ2WFCMG7UF17CW\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "HKB7CU8PWYEHS3A\\Administrator"
+    "user": "RJ2WFCMG7UF17CW\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.127.75",
+  "ipaddress6": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress6_Local Area Connection": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress_Local Area Connection": "10.32.127.75",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:06:09",
+  "macaddress_Local Area Connection": "00:50:56:A2:06:09",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.92 GiB",
-      "available_bytes": 3138375680,
-      "capacity": "26.91%",
+      "available": "2.93 GiB",
+      "available_bytes": 3147616256,
+      "capacity": "26.70%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.08 GiB",
-      "used_bytes": 1155690496
+      "used": "1.07 GiB",
+      "used_bytes": 1146449920
     }
   },
+  "memoryfree": "2.93 GiB",
+  "memoryfree_mb": 3001.80078125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.116.113",
+            "address": "10.32.127.75",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::60bc:b13:61bf:9110%12",
+            "address": "fe80::80be:a6bc:1766:4c99%11",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%12"
+            "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.116.113",
-        "ip6": "fe80::60bc:b13:61bf:9110%12",
-        "mac": "00:50:56:A2:C2:80",
+        "ip": "10.32.127.75",
+        "ip6": "fe80::80be:a6bc:1766:4c99%11",
+        "mac": "00:50:56:A2:06:09",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%12"
+        "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.116.113",
-    "ip6": "fe80::60bc:b13:61bf:9110%12",
-    "mac": "00:50:56:A2:C2:80",
+    "ip": "10.32.127.75",
+    "ip6": "fe80::80be:a6bc:1766:4c99%11",
+    "mac": "00:50:56:A2:06:09",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%12",
+    "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008 R2",
+  "operatingsystemrelease": "2008 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.7.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 440,
-    "uptime": "0:07 hours"
+    "hours": 16,
+    "seconds": 60362,
+    "uptime": "16:46 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "16:46 hours",
+  "uptime_days": 0,
+  "uptime_hours": 16,
+  "uptime_seconds": 60362,
+  "virtual": "vmware"
 }

--- a/facts/3.4/windows-2008-x86_64.facts
+++ b/facts/3.4/windows-2008-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.7.2",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "Phoenix Technologies LTD",
     "product": {
       "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 3f 06 9e 43 30 eb-b3 f4 58 de 6a 3e e5 9f"
+      "serial_number": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.4.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "QFMZ60DYQGU893J\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "D5NOW95YYUDLWEV\\Administrator"
+    "user": "QFMZ60DYQGU893J\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.95",
+  "ipaddress6": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress6_Local Area Connection": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress_Local Area Connection": "10.32.126.95",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.0",
   "kernelrelease": "6.0.6002",
   "kernelversion": "6.0.6002",
+  "macaddress": "00:50:56:A2:E0:07",
+  "macaddress_Local Area Connection": "00:50:56:A2:E0:07",
+  "manufacturer": "Phoenix Technologies LTD",
   "memory": {
     "system": {
-      "available": "3.05 GiB",
-      "available_bytes": 3277975552,
-      "capacity": "23.65%",
+      "available": "3.11 GiB",
+      "available_bytes": 3337281536,
+      "capacity": "22.27%",
       "total": "4.00 GiB",
       "total_bytes": 4293357568,
-      "used": "968.34 MiB",
-      "used_bytes": 1015382016
+      "used": "911.79 MiB",
+      "used_bytes": 956076032
     }
   },
+  "memoryfree": "3.11 GiB",
+  "memoryfree_mb": 3182.6796875,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4094.46484375,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%10",
+  "network6_Local Area Connection": "fe80::%10",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.117.107",
+            "address": "10.32.126.95",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::e9c8:8f06:477c:99fa%11",
+            "address": "fe80::dd24:f5a9:347b:c256%10",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%11"
+            "network": "fe80::%10"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.117.107",
-        "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-        "mac": "00:50:56:A2:B1:DA",
+        "ip": "10.32.126.95",
+        "ip6": "fe80::dd24:f5a9:347b:c256%10",
+        "mac": "00:50:56:A2:E0:07",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%11"
+        "network6": "fe80::%10"
       }
     },
-    "ip": "10.32.117.107",
-    "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-    "mac": "00:50:56:A2:B1:DA",
+    "ip": "10.32.126.95",
+    "ip6": "fe80::dd24:f5a9:347b:c256%10",
+    "mac": "00:50:56:A2:E0:07",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%11",
+    "network6": "fe80::%10",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008",
+  "operatingsystemrelease": "2008",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware Virtual Platform",
   "puppetversion": "4.7.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 15,
-    "seconds": 54940,
-    "uptime": "15:15 hours"
+    "hours": 14,
+    "seconds": 50575,
+    "uptime": "14:02 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "14:02 hours",
+  "uptime_days": 0,
+  "uptime_hours": 14,
+  "uptime_seconds": 50575,
+  "virtual": "vmware"
 }

--- a/facts/3.4/windows-2012 r2-core-x86_64.facts
+++ b/facts/3.4/windows-2012 r2-core-x86_64.facts
@@ -1,60 +1,92 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.7.2",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
-    "manufacturer": "Phoenix Technologies LTD",
+    "manufacturer": "VMware, Inc.",
     "product": {
-      "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 91 42 5a d1 7a 50-73 d9 8a 73 2a ba e5 d9"
+      "name": "VMware7,1",
+      "serial_number": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.4.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "G0ZBZXENEIL32X5\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "GHWYJ7383D7T8XY\\cyg_server"
+    "user": "G0ZBZXENEIL32X5\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.117.89",
+  "ipaddress6": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress6_Ethernet0": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress_Ethernet0": "10.32.117.89",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:72:05",
+  "macaddress_Ethernet0": "00:50:56:A2:72:05",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.03 GiB",
-      "available_bytes": 3251859456,
-      "capacity": "24.28%",
-      "total": "4.00 GiB",
-      "total_bytes": 4294496256,
-      "used": "994.34 MiB",
-      "used_bytes": 1042636800
+      "available": "5.30 GiB",
+      "available_bytes": 5693304832,
+      "capacity": "11.62%",
+      "total": "6.00 GiB",
+      "total_bytes": 6441549824,
+      "used": "713.58 MiB",
+      "used_bytes": 748244992
     }
   },
+  "memoryfree": "5.30 GiB",
+  "memoryfree_mb": 5429.55859375,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
-      "Ethernet": {
+      "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.114.127",
+            "address": "10.32.117.89",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::fd0d:3323:1bb4:680d%12",
+            "address": "fe80::71c4:5555:d38:94fa%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.114.127",
-        "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-        "mac": "00:50:56:A2:34:6A",
+        "ip": "10.32.117.89",
+        "ip6": "fe80::71c4:5555:d38:94fa%12",
+        "mac": "00:50:56:A2:72:05",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,16 +94,19 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.114.127",
-    "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-    "mac": "00:50:56:A2:34:6A",
+    "ip": "10.32.117.89",
+    "ip6": "fe80::71c4:5555:d38:94fa%12",
+    "mac": "00:50:56:A2:72:05",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
     "network6": "fe80::%12",
-    "primary": "Ethernet"
+    "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\pstools;C:\\cygwin64\\bin",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.7.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 0,
-    "hours": 11,
-    "seconds": 41531,
-    "uptime": "11:32 hours"
+    "days": 1,
+    "hours": 24,
+    "seconds": 86906,
+    "uptime": "1 day"
   },
-  "timezone": "Pacific Daylight Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "timezone": "Coordinated Universal Time",
+  "uptime": "1 day",
+  "uptime_days": 1,
+  "uptime_hours": 24,
+  "uptime_seconds": 86906,
+  "virtual": "vmware"
 }

--- a/facts/3.4/windows-2012 r2-x86_64.facts
+++ b/facts/3.4/windows-2012 r2-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.7.2",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 f5 c4 62 f1 23 8a-45 87 85 c8 cc 40 99 c5"
+      "serial_number": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.4.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GTT427VBINBGPOL\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "QYK15CXKD67BH65\\Administrator"
+    "user": "GTT427VBINBGPOL\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.127.212",
+  "ipaddress6": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress6_Ethernet0": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress_Ethernet0": "10.32.127.212",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:D9:94",
+  "macaddress_Ethernet0": "00:50:56:A2:D9:94",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "5.13 GiB",
-      "available_bytes": 5503881216,
-      "capacity": "14.56%",
+      "available": "5.18 GiB",
+      "available_bytes": 5563301888,
+      "capacity": "13.63%",
       "total": "6.00 GiB",
       "total_bytes": 6441549824,
-      "used": "894.23 MiB",
-      "used_bytes": 937668608
+      "used": "837.56 MiB",
+      "used_bytes": 878247936
     }
   },
+  "memoryfree": "5.18 GiB",
+  "memoryfree_mb": 5305.578125,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.113.108",
+            "address": "10.32.127.212",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::d432:9626:e5c4:73fa%12",
+            "address": "fe80::a0b5:f374:6703:1ec6%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.108",
-        "ip6": "fe80::d432:9626:e5c4:73fa%12",
-        "mac": "00:50:56:A2:D5:08",
+        "ip": "10.32.127.212",
+        "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+        "mac": "00:50:56:A2:D9:94",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.113.108",
-    "ip6": "fe80::d432:9626:e5c4:73fa%12",
-    "mac": "00:50:56:A2:D5:08",
+    "ip": "10.32.127.212",
+    "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+    "mac": "00:50:56:A2:D9:94",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.7.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 3,
-    "seconds": 12085,
-    "uptime": "3:21 hours"
+    "hours": 0,
+    "seconds": 1704,
+    "uptime": "0:28 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "0:28 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 1704,
+  "virtual": "vmware"
 }

--- a/facts/3.4/windows-2012-x86_64.facts
+++ b/facts/3.4/windows-2012-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.7.2",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d0 54 b4 68 27 15-5e 55 a0 aa a1 c4 b6 85"
+      "serial_number": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.4.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "WX8QEA42SDYVTT6\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "O1JC0NKUU0IWW8R\\Administrator"
+    "user": "WX8QEA42SDYVTT6\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.136",
+  "ipaddress6": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress6_Ethernet0": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress_Ethernet0": "10.32.112.136",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.2",
   "kernelrelease": "6.2.9200",
   "kernelversion": "6.2.9200",
+  "macaddress": "00:50:56:A2:5B:88",
+  "macaddress_Ethernet0": "00:50:56:A2:5B:88",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.13 GiB",
-      "available_bytes": 3360129024,
-      "capacity": "21.75%",
+      "available": "3.21 GiB",
+      "available_bytes": 3448303616,
+      "capacity": "19.70%",
       "total": "4.00 GiB",
       "total_bytes": 4294062080,
-      "used": "890.67 MiB",
-      "used_bytes": 933933056
+      "used": "806.58 MiB",
+      "used_bytes": 845758464
     }
   },
+  "memoryfree": "3.21 GiB",
+  "memoryfree_mb": 3288.55859375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.13671875,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.115.189",
+            "address": "10.32.112.136",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::b90b:b82d:cd47:12fc%13",
+            "address": "fe80::256a:cde6:f021:6c49%12",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%13"
+            "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.115.189",
-        "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-        "mac": "00:50:56:A2:92:62",
+        "ip": "10.32.112.136",
+        "ip6": "fe80::256a:cde6:f021:6c49%12",
+        "mac": "00:50:56:A2:5B:88",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%13"
+        "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.115.189",
-    "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-    "mac": "00:50:56:A2:92:62",
+    "ip": "10.32.112.136",
+    "ip6": "fe80::256a:cde6:f021:6c49%12",
+    "mac": "00:50:56:A2:5B:88",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%13",
+    "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012",
+  "operatingsystemrelease": "2012",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.7.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 12,
-    "seconds": 46586,
-    "uptime": "12:56 hours"
+    "hours": 15,
+    "seconds": 54705,
+    "uptime": "15:11 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "15:11 hours",
+  "uptime_days": 0,
+  "uptime_hours": 15,
+  "uptime_seconds": 54705,
+  "virtual": "vmware"
 }

--- a/facts/3.4/windows-2016-x86_64.facts
+++ b/facts/3.4/windows-2016-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.7.2",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d8 fb 34 7b b4 e8-dd 91 bd ef cc 32 1e 6c"
+      "serial_number": "VMware-42 22 28 b9 e9 7f 7e ac-48 14 76 dc f2 42 91 47"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.4.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GR3WVWP2B63LSOM\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "IHGAJGT1OU8FTDM\\Administrator"
+    "user": "GR3WVWP2B63LSOM\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.60",
+  "ipaddress6": "fe80::48:3cd:d72:aa17%5",
+  "ipaddress6_Ethernet0": "fe80::48:3cd:d72:aa17%5",
+  "ipaddress_Ethernet0": "10.32.125.60",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:38:BE",
+  "macaddress_Ethernet0": "00:50:56:A2:38:BE",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
       "available": "2.91 GiB",
-      "available_bytes": 3128377344,
-      "capacity": "27.15%",
+      "available_bytes": 3122618368,
+      "capacity": "27.28%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
       "used": "1.09 GiB",
-      "used_bytes": 1165680640
+      "used_bytes": 1171439616
     }
   },
+  "memoryfree": "2.91 GiB",
+  "memoryfree_mb": 2977.9609375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%5",
+  "network6_Ethernet0": "fe80::%5",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.119.232",
+            "address": "10.32.125.60",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::99c3:c512:bd3:5f63%3",
+            "address": "fe80::48:3cd:d72:aa17%5",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%3"
+            "network": "fe80::%5"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.119.232",
-        "ip6": "fe80::99c3:c512:bd3:5f63%3",
-        "mac": "00:50:56:A2:68:15",
+        "ip": "10.32.125.60",
+        "ip6": "fe80::48:3cd:d72:aa17%5",
+        "mac": "00:50:56:A2:38:BE",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%3"
+        "network6": "fe80::%5"
       }
     },
-    "ip": "10.32.119.232",
-    "ip6": "fe80::99c3:c512:bd3:5f63%3",
-    "mac": "00:50:56:A2:68:15",
+    "ip": "10.32.125.60",
+    "ip6": "fe80::48:3cd:d72:aa17%5",
+    "mac": "00:50:56:A2:38:BE",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%3",
+    "network6": "fe80::%5",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2016",
+  "operatingsystemrelease": "2016",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.7.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 28 b9 e9 7f 7e ac-48 14 76 dc f2 42 91 47",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 1,
-    "seconds": 4738,
-    "uptime": "1:18 hours"
+    "hours": 8,
+    "seconds": 29842,
+    "uptime": "8:17 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "uptime": "8:17 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29842,
+  "virtual": "vmware"
 }

--- a/facts/3.4/windows-7-x86_64.facts
+++ b/facts/3.4/windows-7-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.7.2",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 a6 6f 63 84 0d 53-07 bc 72 79 02 59 33 7a"
+      "serial_number": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.4.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "N6IFGFZXW976ITI\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "G089LVS4X1ERMNM\\Administrator"
+    "user": "N6IFGFZXW976ITI\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.90",
+  "ipaddress6": "fe80::2121:2899:8986:e379%11",
+  "ipaddress6_Local Area Connection": "fe80::2121:2899:8986:e379%11",
+  "ipaddress_Local Area Connection": "10.32.126.90",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:78:83",
+  "macaddress_Local Area Connection": "00:50:56:A2:78:83",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.91 GiB",
-      "available_bytes": 3126980608,
-      "capacity": "27.18%",
+      "available": "2.93 GiB",
+      "available_bytes": 3148636160,
+      "capacity": "26.67%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.09 GiB",
-      "used_bytes": 1167085568
+      "used": "1.07 GiB",
+      "used_bytes": 1145430016
     }
   },
+  "memoryfree": "2.93 GiB",
+  "memoryfree_mb": 3002.7734375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.126.73",
+            "address": "10.32.126.90",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::b4bd:32dd:a5c:f8a%12",
+            "address": "fe80::2121:2899:8986:e379%11",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%12"
+            "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.126.73",
-        "ip6": "fe80::b4bd:32dd:a5c:f8a%12",
-        "mac": "00:50:56:A2:EF:51",
+        "ip": "10.32.126.90",
+        "ip6": "fe80::2121:2899:8986:e379%11",
+        "mac": "00:50:56:A2:78:83",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%12"
+        "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.126.73",
-    "ip6": "fe80::b4bd:32dd:a5c:f8a%12",
-    "mac": "00:50:56:A2:EF:51",
+    "ip": "10.32.126.90",
+    "ip6": "fe80::2121:2899:8986:e379%11",
+    "mac": "00:50:56:A2:78:83",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%12",
+    "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "7",
+  "operatingsystemrelease": "7",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.7.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 16,
-    "seconds": 58940,
-    "uptime": "16:22 hours"
+    "hours": 8,
+    "seconds": 29376,
+    "uptime": "8:09 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "8:09 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29376,
+  "virtual": "vmware"
 }

--- a/facts/3.4/windows-8.1-x86_64.facts
+++ b/facts/3.4/windows-8.1-x86_64.facts
@@ -1,37 +1,69 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.7.2",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 0f 99 71 37 c9 34 5c-60 e2 5f ad 59 28 d7 53"
+      "serial_number": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.4.2",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "B5GMZC25YP3WRFT\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "TGPX4C0ZOVOW6AL\\Administrator"
+    "user": "B5GMZC25YP3WRFT\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.84",
+  "ipaddress6": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress6_Ethernet0": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress_Ethernet0": "10.32.125.84",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:FD:34",
+  "macaddress_Ethernet0": "00:50:56:A2:FD:34",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.48 GiB",
-      "available_bytes": 2668097536,
-      "capacity": "37.87%",
+      "available": "2.40 GiB",
+      "available_bytes": 2572124160,
+      "capacity": "40.10%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.51 GiB",
-      "used_bytes": 1625968640
+      "used": "1.60 GiB",
+      "used_bytes": 1721942016
     }
   },
+  "memoryfree": "2.40 GiB",
+  "memoryfree_mb": 2452.96875,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
-    "dhcp": "10.32.22.9",
+    "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.126.10",
+            "address": "10.32.125.84",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::d9b6:d8a2:98e1:bcf0%3",
+            "address": "fe80::e490:85dc:9a71:4d9e%3",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%3"
           }
         ],
-        "dhcp": "10.32.22.9",
-        "ip": "10.32.126.10",
-        "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-        "mac": "00:50:56:8F:42:E3",
+        "dhcp": "10.32.22.10",
+        "ip": "10.32.125.84",
+        "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+        "mac": "00:50:56:A2:FD:34",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.126.10",
-    "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-    "mac": "00:50:56:8F:42:E3",
+    "ip": "10.32.125.84",
+    "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+    "mac": "00:50:56:A2:FD:34",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "8.1",
+  "operatingsystemrelease": "8.1",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.7.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 11,
-    "hours": 275,
-    "seconds": 992951,
-    "uptime": "11 days"
+    "days": 0,
+    "hours": 18,
+    "seconds": 66620,
+    "uptime": "18:30 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "18:30 hours",
+  "uptime_days": 0,
+  "uptime_hours": 18,
+  "uptime_seconds": 66620,
+  "virtual": "vmware"
 }

--- a/facts/3.5/windows-10-i386.facts
+++ b/facts/3.5/windows-10-i386.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.8.3",
+  "architecture": "x86",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 ca fe f0 e7 64 ba-7e c1 ac 81 ec 79 2a c9"
+      "serial_number": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.5.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "i686",
+  "hostname": "foo",
+  "id": "CAYR11ES3BMJ6UG\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "CD9O9NMEXAPI3GF\\Administrator"
+    "user": "CAYR11ES3BMJ6UG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.121.213",
+  "ipaddress6": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress6_Ethernet0": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress_Ethernet0": "10.32.121.213",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:72:55",
+  "macaddress_Ethernet0": "00:50:56:A2:72:55",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "1.89 GiB",
-      "available_bytes": 2025959424,
-      "capacity": "37.09%",
+      "available": "1.88 GiB",
+      "available_bytes": 2016202752,
+      "capacity": "37.39%",
       "total": "3.00 GiB",
       "total_bytes": 3220324352,
-      "used": "1.11 GiB",
-      "used_bytes": 1194364928
+      "used": "1.12 GiB",
+      "used_bytes": 1204121600
     }
   },
+  "memoryfree": "1.88 GiB",
+  "memoryfree_mb": 1922.80078125,
+  "memorysize": "3.00 GiB",
+  "memorysize_mb": 3071.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.120.121",
+            "address": "10.32.121.213",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::45d7:5af5:8f53:8392%5",
+            "address": "fe80::4dab:3df1:6f45:ee04%3",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%5"
+            "network": "fe80::%3"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.120.121",
-        "ip6": "fe80::45d7:5af5:8f53:8392%5",
-        "mac": "00:50:56:A2:D4:F1",
+        "ip": "10.32.121.213",
+        "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+        "mac": "00:50:56:A2:72:55",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%5"
+        "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.120.121",
-    "ip6": "fe80::45d7:5af5:8f53:8392%5",
-    "mac": "00:50:56:A2:D4:F1",
+    "ip": "10.32.121.213",
+    "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+    "mac": "00:50:56:A2:72:55",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%5",
+    "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10",
+  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x86",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.8.2",
   "ruby": {
     "platform": "i386-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "i386-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 879,
-    "uptime": "0:14 hours"
+    "hours": 6,
+    "seconds": 23206,
+    "uptime": "6:26 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:26 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 23206,
+  "virtual": "vmware"
 }

--- a/facts/3.5/windows-10-x86_64.facts
+++ b/facts/3.5/windows-10-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.8.3",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 b9 12 ec 3b 6e ab-61 61 29 cf f4 72 99 c3"
+      "serial_number": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.5.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "V46YN43Q8ZY3NYG\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "PQX8SDC5TGXO8LI\\Administrator"
+    "user": "V46YN43Q8ZY3NYG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.130",
+  "ipaddress6": "fe80::e110:a74a:480:4409%4",
+  "ipaddress6_Ethernet0": "fe80::e110:a74a:480:4409%4",
+  "ipaddress_Ethernet0": "10.32.112.130",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:BB:13",
+  "macaddress_Ethernet0": "00:50:56:A2:BB:13",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.70 GiB",
-      "available_bytes": 2896904192,
-      "capacity": "32.54%",
+      "available": "2.60 GiB",
+      "available_bytes": 2794139648,
+      "capacity": "34.93%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "1.30 GiB",
-      "used_bytes": 1397153792
+      "used": "1.40 GiB",
+      "used_bytes": 1499918336
     }
   },
+  "memoryfree": "2.60 GiB",
+  "memoryfree_mb": 2664.69921875,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%4",
+  "network6_Ethernet0": "fe80::%4",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.113.158",
+            "address": "10.32.112.130",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::753c:44f6:3bb1:cb0c%2",
+            "address": "fe80::e110:a74a:480:4409%4",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%2"
+            "network": "fe80::%4"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.158",
-        "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-        "mac": "00:50:56:A2:B1:5B",
+        "ip": "10.32.112.130",
+        "ip6": "fe80::e110:a74a:480:4409%4",
+        "mac": "00:50:56:A2:BB:13",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%2"
+        "network6": "fe80::%4"
       }
     },
-    "ip": "10.32.113.158",
-    "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-    "mac": "00:50:56:A2:B1:5B",
+    "ip": "10.32.112.130",
+    "ip6": "fe80::e110:a74a:480:4409%4",
+    "mac": "00:50:56:A2:BB:13",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%2",
+    "network6": "fe80::%4",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10",
+  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.8.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 15,
-    "seconds": 57587,
-    "uptime": "15:59 hours"
+    "hours": 6,
+    "seconds": 23036,
+    "uptime": "6:23 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:23 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 23036,
+  "virtual": "vmware"
 }

--- a/facts/3.5/windows-2008 r2-x86_64.facts
+++ b/facts/3.5/windows-2008 r2-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.8.3",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 6f a5 43 75 12 ae-15 76 ec 76 47 5d 25 9a"
+      "serial_number": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.5.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "RJ2WFCMG7UF17CW\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "HKB7CU8PWYEHS3A\\Administrator"
+    "user": "RJ2WFCMG7UF17CW\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.127.75",
+  "ipaddress6": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress6_Local Area Connection": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress_Local Area Connection": "10.32.127.75",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:06:09",
+  "macaddress_Local Area Connection": "00:50:56:A2:06:09",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.90 GiB",
-      "available_bytes": 3111976960,
-      "capacity": "27.53%",
+      "available": "2.92 GiB",
+      "available_bytes": 3139387392,
+      "capacity": "26.89%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.10 GiB",
-      "used_bytes": 1182089216
+      "used": "1.08 GiB",
+      "used_bytes": 1154678784
     }
   },
+  "memoryfree": "2.92 GiB",
+  "memoryfree_mb": 2993.953125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.116.113",
+            "address": "10.32.127.75",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::60bc:b13:61bf:9110%12",
+            "address": "fe80::80be:a6bc:1766:4c99%11",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%12"
+            "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.116.113",
-        "ip6": "fe80::60bc:b13:61bf:9110%12",
-        "mac": "00:50:56:A2:C2:80",
+        "ip": "10.32.127.75",
+        "ip6": "fe80::80be:a6bc:1766:4c99%11",
+        "mac": "00:50:56:A2:06:09",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%12"
+        "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.116.113",
-    "ip6": "fe80::60bc:b13:61bf:9110%12",
-    "mac": "00:50:56:A2:C2:80",
+    "ip": "10.32.127.75",
+    "ip6": "fe80::80be:a6bc:1766:4c99%11",
+    "mac": "00:50:56:A2:06:09",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%12",
+    "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008 R2",
+  "operatingsystemrelease": "2008 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.8.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 361,
-    "uptime": "0:06 hours"
+    "hours": 16,
+    "seconds": 60297,
+    "uptime": "16:44 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "16:44 hours",
+  "uptime_days": 0,
+  "uptime_hours": 16,
+  "uptime_seconds": 60297,
+  "virtual": "vmware"
 }

--- a/facts/3.5/windows-2008-x86_64.facts
+++ b/facts/3.5/windows-2008-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.8.3",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "Phoenix Technologies LTD",
     "product": {
       "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 3f 06 9e 43 30 eb-b3 f4 58 de 6a 3e e5 9f"
+      "serial_number": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.5.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "QFMZ60DYQGU893J\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "D5NOW95YYUDLWEV\\Administrator"
+    "user": "QFMZ60DYQGU893J\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.95",
+  "ipaddress6": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress6_Local Area Connection": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress_Local Area Connection": "10.32.126.95",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.0",
   "kernelrelease": "6.0.6002",
   "kernelversion": "6.0.6002",
+  "macaddress": "00:50:56:A2:E0:07",
+  "macaddress_Local Area Connection": "00:50:56:A2:E0:07",
+  "manufacturer": "Phoenix Technologies LTD",
   "memory": {
     "system": {
-      "available": "3.05 GiB",
-      "available_bytes": 3275214848,
-      "capacity": "23.71%",
+      "available": "3.08 GiB",
+      "available_bytes": 3310211072,
+      "capacity": "22.90%",
       "total": "4.00 GiB",
       "total_bytes": 4293357568,
-      "used": "970.98 MiB",
-      "used_bytes": 1018142720
+      "used": "937.60 MiB",
+      "used_bytes": 983146496
     }
   },
+  "memoryfree": "3.08 GiB",
+  "memoryfree_mb": 3156.86328125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4094.46484375,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%10",
+  "network6_Local Area Connection": "fe80::%10",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.117.107",
+            "address": "10.32.126.95",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::e9c8:8f06:477c:99fa%11",
+            "address": "fe80::dd24:f5a9:347b:c256%10",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%11"
+            "network": "fe80::%10"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.117.107",
-        "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-        "mac": "00:50:56:A2:B1:DA",
+        "ip": "10.32.126.95",
+        "ip6": "fe80::dd24:f5a9:347b:c256%10",
+        "mac": "00:50:56:A2:E0:07",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%11"
+        "network6": "fe80::%10"
       }
     },
-    "ip": "10.32.117.107",
-    "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-    "mac": "00:50:56:A2:B1:DA",
+    "ip": "10.32.126.95",
+    "ip6": "fe80::dd24:f5a9:347b:c256%10",
+    "mac": "00:50:56:A2:E0:07",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%11",
+    "network6": "fe80::%10",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008",
+  "operatingsystemrelease": "2008",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware Virtual Platform",
   "puppetversion": "4.8.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 15,
-    "seconds": 54797,
-    "uptime": "15:13 hours"
+    "hours": 14,
+    "seconds": 50423,
+    "uptime": "14:00 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "14:00 hours",
+  "uptime_days": 0,
+  "uptime_hours": 14,
+  "uptime_seconds": 50423,
+  "virtual": "vmware"
 }

--- a/facts/3.5/windows-2012 r2-core-x86_64.facts
+++ b/facts/3.5/windows-2012 r2-core-x86_64.facts
@@ -1,60 +1,92 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.8.3",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
-    "manufacturer": "Phoenix Technologies LTD",
+    "manufacturer": "VMware, Inc.",
     "product": {
-      "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 91 42 5a d1 7a 50-73 d9 8a 73 2a ba e5 d9"
+      "name": "VMware7,1",
+      "serial_number": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.5.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "G0ZBZXENEIL32X5\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "GHWYJ7383D7T8XY\\cyg_server"
+    "user": "G0ZBZXENEIL32X5\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.117.89",
+  "ipaddress6": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress6_Ethernet0": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress_Ethernet0": "10.32.117.89",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:72:05",
+  "macaddress_Ethernet0": "00:50:56:A2:72:05",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.97 GiB",
-      "available_bytes": 3190296576,
-      "capacity": "25.71%",
-      "total": "4.00 GiB",
-      "total_bytes": 4294496256,
-      "used": "1.03 GiB",
-      "used_bytes": 1104199680
+      "available": "5.28 GiB",
+      "available_bytes": 5665005568,
+      "capacity": "12.06%",
+      "total": "6.00 GiB",
+      "total_bytes": 6441549824,
+      "used": "740.57 MiB",
+      "used_bytes": 776544256
     }
   },
+  "memoryfree": "5.28 GiB",
+  "memoryfree_mb": 5402.5703125,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
-      "Ethernet": {
+      "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.114.127",
+            "address": "10.32.117.89",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::fd0d:3323:1bb4:680d%12",
+            "address": "fe80::71c4:5555:d38:94fa%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.114.127",
-        "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-        "mac": "00:50:56:A2:34:6A",
+        "ip": "10.32.117.89",
+        "ip6": "fe80::71c4:5555:d38:94fa%12",
+        "mac": "00:50:56:A2:72:05",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,16 +94,19 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.114.127",
-    "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-    "mac": "00:50:56:A2:34:6A",
+    "ip": "10.32.117.89",
+    "ip6": "fe80::71c4:5555:d38:94fa%12",
+    "mac": "00:50:56:A2:72:05",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
     "network6": "fe80::%12",
-    "primary": "Ethernet"
+    "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\pstools;C:\\cygwin64\\bin",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.8.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 0,
-    "hours": 11,
-    "seconds": 41473,
-    "uptime": "11:31 hours"
+    "days": 1,
+    "hours": 24,
+    "seconds": 86843,
+    "uptime": "1 day"
   },
-  "timezone": "Pacific Daylight Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "timezone": "Coordinated Universal Time",
+  "uptime": "1 day",
+  "uptime_days": 1,
+  "uptime_hours": 24,
+  "uptime_seconds": 86843,
+  "virtual": "vmware"
 }

--- a/facts/3.5/windows-2012 r2-x86_64.facts
+++ b/facts/3.5/windows-2012 r2-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.8.3",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 f5 c4 62 f1 23 8a-45 87 85 c8 cc 40 99 c5"
+      "serial_number": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.5.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GTT427VBINBGPOL\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "QYK15CXKD67BH65\\Administrator"
+    "user": "GTT427VBINBGPOL\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.127.212",
+  "ipaddress6": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress6_Ethernet0": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress_Ethernet0": "10.32.127.212",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:D9:94",
+  "macaddress_Ethernet0": "00:50:56:A2:D9:94",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "5.09 GiB",
-      "available_bytes": 5467353088,
-      "capacity": "15.12%",
+      "available": "5.17 GiB",
+      "available_bytes": 5547479040,
+      "capacity": "13.88%",
       "total": "6.00 GiB",
       "total_bytes": 6441549824,
-      "used": "929.07 MiB",
-      "used_bytes": 974196736
+      "used": "852.65 MiB",
+      "used_bytes": 894070784
     }
   },
+  "memoryfree": "5.17 GiB",
+  "memoryfree_mb": 5290.48828125,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.113.108",
+            "address": "10.32.127.212",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::d432:9626:e5c4:73fa%12",
+            "address": "fe80::a0b5:f374:6703:1ec6%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.108",
-        "ip6": "fe80::d432:9626:e5c4:73fa%12",
-        "mac": "00:50:56:A2:D5:08",
+        "ip": "10.32.127.212",
+        "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+        "mac": "00:50:56:A2:D9:94",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.113.108",
-    "ip6": "fe80::d432:9626:e5c4:73fa%12",
-    "mac": "00:50:56:A2:D5:08",
+    "ip": "10.32.127.212",
+    "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+    "mac": "00:50:56:A2:D9:94",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.8.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 3,
-    "seconds": 12029,
-    "uptime": "3:20 hours"
+    "hours": 0,
+    "seconds": 1645,
+    "uptime": "0:27 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "0:27 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 1645,
+  "virtual": "vmware"
 }

--- a/facts/3.5/windows-2012-x86_64.facts
+++ b/facts/3.5/windows-2012-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.8.3",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d0 54 b4 68 27 15-5e 55 a0 aa a1 c4 b6 85"
+      "serial_number": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.5.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "WX8QEA42SDYVTT6\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "O1JC0NKUU0IWW8R\\Administrator"
+    "user": "WX8QEA42SDYVTT6\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.136",
+  "ipaddress6": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress6_Ethernet0": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress_Ethernet0": "10.32.112.136",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.2",
   "kernelrelease": "6.2.9200",
   "kernelversion": "6.2.9200",
+  "macaddress": "00:50:56:A2:5B:88",
+  "macaddress_Ethernet0": "00:50:56:A2:5B:88",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.13 GiB",
-      "available_bytes": 3360964608,
-      "capacity": "21.73%",
+      "available": "3.19 GiB",
+      "available_bytes": 3425869824,
+      "capacity": "20.22%",
       "total": "4.00 GiB",
       "total_bytes": 4294062080,
-      "used": "889.87 MiB",
-      "used_bytes": 933097472
+      "used": "827.97 MiB",
+      "used_bytes": 868192256
     }
   },
+  "memoryfree": "3.19 GiB",
+  "memoryfree_mb": 3267.1640625,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.13671875,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.115.189",
+            "address": "10.32.112.136",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::b90b:b82d:cd47:12fc%13",
+            "address": "fe80::256a:cde6:f021:6c49%12",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%13"
+            "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.115.189",
-        "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-        "mac": "00:50:56:A2:92:62",
+        "ip": "10.32.112.136",
+        "ip6": "fe80::256a:cde6:f021:6c49%12",
+        "mac": "00:50:56:A2:5B:88",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%13"
+        "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.115.189",
-    "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-    "mac": "00:50:56:A2:92:62",
+    "ip": "10.32.112.136",
+    "ip6": "fe80::256a:cde6:f021:6c49%12",
+    "mac": "00:50:56:A2:5B:88",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%13",
+    "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012",
+  "operatingsystemrelease": "2012",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.8.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 12,
-    "seconds": 46528,
-    "uptime": "12:55 hours"
+    "hours": 15,
+    "seconds": 54648,
+    "uptime": "15:10 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "15:10 hours",
+  "uptime_days": 0,
+  "uptime_hours": 15,
+  "uptime_seconds": 54648,
+  "virtual": "vmware"
 }

--- a/facts/3.5/windows-2016-x86_64.facts
+++ b/facts/3.5/windows-2016-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.8.3",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d8 fb 34 7b b4 e8-dd 91 bd ef cc 32 1e 6c"
+      "serial_number": "VMware-42 22 28 b9 e9 7f 7e ac-48 14 76 dc f2 42 91 47"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.5.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GR3WVWP2B63LSOM\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "IHGAJGT1OU8FTDM\\Administrator"
+    "user": "GR3WVWP2B63LSOM\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.60",
+  "ipaddress6": "fe80::48:3cd:d72:aa17%5",
+  "ipaddress6_Ethernet0": "fe80::48:3cd:d72:aa17%5",
+  "ipaddress_Ethernet0": "10.32.125.60",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:38:BE",
+  "macaddress_Ethernet0": "00:50:56:A2:38:BE",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.91 GiB",
-      "available_bytes": 3127754752,
-      "capacity": "27.16%",
+      "available": "2.88 GiB",
+      "available_bytes": 3089354752,
+      "capacity": "28.06%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "1.09 GiB",
-      "used_bytes": 1166303232
+      "used": "1.12 GiB",
+      "used_bytes": 1204703232
     }
   },
+  "memoryfree": "2.88 GiB",
+  "memoryfree_mb": 2946.23828125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%5",
+  "network6_Ethernet0": "fe80::%5",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.119.232",
+            "address": "10.32.125.60",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::99c3:c512:bd3:5f63%3",
+            "address": "fe80::48:3cd:d72:aa17%5",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%3"
+            "network": "fe80::%5"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.119.232",
-        "ip6": "fe80::99c3:c512:bd3:5f63%3",
-        "mac": "00:50:56:A2:68:15",
+        "ip": "10.32.125.60",
+        "ip6": "fe80::48:3cd:d72:aa17%5",
+        "mac": "00:50:56:A2:38:BE",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%3"
+        "network6": "fe80::%5"
       }
     },
-    "ip": "10.32.119.232",
-    "ip6": "fe80::99c3:c512:bd3:5f63%3",
-    "mac": "00:50:56:A2:68:15",
+    "ip": "10.32.125.60",
+    "ip6": "fe80::48:3cd:d72:aa17%5",
+    "mac": "00:50:56:A2:38:BE",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%3",
+    "network6": "fe80::%5",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2016",
+  "operatingsystemrelease": "2016",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.8.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 28 b9 e9 7f 7e ac-48 14 76 dc f2 42 91 47",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 1,
-    "seconds": 4665,
-    "uptime": "1:17 hours"
+    "hours": 8,
+    "seconds": 29756,
+    "uptime": "8:15 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "uptime": "8:15 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29756,
+  "virtual": "vmware"
 }

--- a/facts/3.5/windows-7-x86_64.facts
+++ b/facts/3.5/windows-7-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.8.3",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 a6 6f 63 84 0d 53-07 bc 72 79 02 59 33 7a"
+      "serial_number": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.5.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "N6IFGFZXW976ITI\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "G089LVS4X1ERMNM\\Administrator"
+    "user": "N6IFGFZXW976ITI\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.90",
+  "ipaddress6": "fe80::2121:2899:8986:e379%11",
+  "ipaddress6_Local Area Connection": "fe80::2121:2899:8986:e379%11",
+  "ipaddress_Local Area Connection": "10.32.126.90",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:78:83",
+  "macaddress_Local Area Connection": "00:50:56:A2:78:83",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.90 GiB",
-      "available_bytes": 3110576128,
-      "capacity": "27.56%",
+      "available": "2.93 GiB",
+      "available_bytes": 3141615616,
+      "capacity": "26.84%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.10 GiB",
-      "used_bytes": 1183490048
+      "used": "1.07 GiB",
+      "used_bytes": 1152450560
     }
   },
+  "memoryfree": "2.93 GiB",
+  "memoryfree_mb": 2996.078125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.126.73",
+            "address": "10.32.126.90",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::b4bd:32dd:a5c:f8a%12",
+            "address": "fe80::2121:2899:8986:e379%11",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%12"
+            "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.126.73",
-        "ip6": "fe80::b4bd:32dd:a5c:f8a%12",
-        "mac": "00:50:56:A2:EF:51",
+        "ip": "10.32.126.90",
+        "ip6": "fe80::2121:2899:8986:e379%11",
+        "mac": "00:50:56:A2:78:83",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%12"
+        "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.126.73",
-    "ip6": "fe80::b4bd:32dd:a5c:f8a%12",
-    "mac": "00:50:56:A2:EF:51",
+    "ip": "10.32.126.90",
+    "ip6": "fe80::2121:2899:8986:e379%11",
+    "mac": "00:50:56:A2:78:83",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%12",
+    "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "7",
+  "operatingsystemrelease": "7",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.8.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 16,
-    "seconds": 58869,
-    "uptime": "16:21 hours"
+    "hours": 8,
+    "seconds": 29311,
+    "uptime": "8:08 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "8:08 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29311,
+  "virtual": "vmware"
 }

--- a/facts/3.5/windows-8.1-x86_64.facts
+++ b/facts/3.5/windows-8.1-x86_64.facts
@@ -1,37 +1,69 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.8.3",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 0f 99 71 37 c9 34 5c-60 e2 5f ad 59 28 d7 53"
+      "serial_number": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.5.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "B5GMZC25YP3WRFT\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "TGPX4C0ZOVOW6AL\\Administrator"
+    "user": "B5GMZC25YP3WRFT\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.84",
+  "ipaddress6": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress6_Ethernet0": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress_Ethernet0": "10.32.125.84",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:FD:34",
+  "macaddress_Ethernet0": "00:50:56:A2:FD:34",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.48 GiB",
-      "available_bytes": 2661883904,
-      "capacity": "38.01%",
+      "available": "2.41 GiB",
+      "available_bytes": 2592428032,
+      "capacity": "39.63%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.52 GiB",
-      "used_bytes": 1632182272
+      "used": "1.58 GiB",
+      "used_bytes": 1701638144
     }
   },
+  "memoryfree": "2.41 GiB",
+  "memoryfree_mb": 2472.33203125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
-    "dhcp": "10.32.22.9",
+    "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.126.10",
+            "address": "10.32.125.84",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::d9b6:d8a2:98e1:bcf0%3",
+            "address": "fe80::e490:85dc:9a71:4d9e%3",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%3"
           }
         ],
-        "dhcp": "10.32.22.9",
-        "ip": "10.32.126.10",
-        "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-        "mac": "00:50:56:8F:42:E3",
+        "dhcp": "10.32.22.10",
+        "ip": "10.32.125.84",
+        "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+        "mac": "00:50:56:A2:FD:34",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.126.10",
-    "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-    "mac": "00:50:56:8F:42:E3",
+    "ip": "10.32.125.84",
+    "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+    "mac": "00:50:56:A2:FD:34",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "8.1",
+  "operatingsystemrelease": "8.1",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.8.2",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 11,
-    "hours": 275,
-    "seconds": 992880,
-    "uptime": "11 days"
+    "days": 0,
+    "hours": 18,
+    "seconds": 66551,
+    "uptime": "18:29 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "18:29 hours",
+  "uptime_days": 0,
+  "uptime_hours": 18,
+  "uptime_seconds": 66551,
+  "virtual": "vmware"
 }

--- a/facts/3.6/windows-10-i386.facts
+++ b/facts/3.6/windows-10-i386.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.10.4",
+  "architecture": "x86",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 ca fe f0 e7 64 ba-7e c1 ac 81 ec 79 2a c9"
+      "serial_number": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.6.5",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "i686",
+  "hostname": "foo",
+  "id": "CAYR11ES3BMJ6UG\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "CD9O9NMEXAPI3GF\\Administrator"
+    "user": "CAYR11ES3BMJ6UG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.121.213",
+  "ipaddress6": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress6_Ethernet0": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress_Ethernet0": "10.32.121.213",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:72:55",
+  "macaddress_Ethernet0": "00:50:56:A2:72:55",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "1.91 GiB",
-      "available_bytes": 2049454080,
-      "capacity": "36.36%",
+      "available": "1.82 GiB",
+      "available_bytes": 1959104512,
+      "capacity": "39.16%",
       "total": "3.00 GiB",
       "total_bytes": 3220324352,
-      "used": "1.09 GiB",
-      "used_bytes": 1170870272
+      "used": "1.17 GiB",
+      "used_bytes": 1261219840
     }
   },
+  "memoryfree": "1.82 GiB",
+  "memoryfree_mb": 1868.34765625,
+  "memorysize": "3.00 GiB",
+  "memorysize_mb": 3071.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.120.121",
+            "address": "10.32.121.213",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::45d7:5af5:8f53:8392%5",
+            "address": "fe80::4dab:3df1:6f45:ee04%3",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%5"
+            "network": "fe80::%3"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.120.121",
-        "ip6": "fe80::45d7:5af5:8f53:8392%5",
-        "mac": "00:50:56:A2:D4:F1",
+        "ip": "10.32.121.213",
+        "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+        "mac": "00:50:56:A2:72:55",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%5"
+        "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.120.121",
-    "ip6": "fe80::45d7:5af5:8f53:8392%5",
-    "mac": "00:50:56:A2:D4:F1",
+    "ip": "10.32.121.213",
+    "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+    "mac": "00:50:56:A2:72:55",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%5",
+    "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10",
+  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x86",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.10.4",
   "ruby": {
     "platform": "i386-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "i386-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 795,
-    "uptime": "0:13 hours"
+    "hours": 6,
+    "seconds": 23119,
+    "uptime": "6:25 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:25 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 23119,
+  "virtual": "vmware"
 }

--- a/facts/3.6/windows-10-x86_64.facts
+++ b/facts/3.6/windows-10-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.10.4",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 b9 12 ec 3b 6e ab-61 61 29 cf f4 72 99 c3"
+      "serial_number": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.6.5",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "V46YN43Q8ZY3NYG\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "PQX8SDC5TGXO8LI\\Administrator"
+    "user": "V46YN43Q8ZY3NYG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.130",
+  "ipaddress6": "fe80::e110:a74a:480:4409%4",
+  "ipaddress6_Ethernet0": "fe80::e110:a74a:480:4409%4",
+  "ipaddress_Ethernet0": "10.32.112.130",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:BB:13",
+  "macaddress_Ethernet0": "00:50:56:A2:BB:13",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.69 GiB",
-      "available_bytes": 2886901760,
-      "capacity": "32.77%",
+      "available": "2.64 GiB",
+      "available_bytes": 2839240704,
+      "capacity": "33.88%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "1.31 GiB",
-      "used_bytes": 1407156224
+      "used": "1.35 GiB",
+      "used_bytes": 1454817280
     }
   },
+  "memoryfree": "2.64 GiB",
+  "memoryfree_mb": 2707.7109375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%4",
+  "network6_Ethernet0": "fe80::%4",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.113.158",
+            "address": "10.32.112.130",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::753c:44f6:3bb1:cb0c%2",
+            "address": "fe80::e110:a74a:480:4409%4",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%2"
+            "network": "fe80::%4"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.158",
-        "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-        "mac": "00:50:56:A2:B1:5B",
+        "ip": "10.32.112.130",
+        "ip6": "fe80::e110:a74a:480:4409%4",
+        "mac": "00:50:56:A2:BB:13",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%2"
+        "network6": "fe80::%4"
       }
     },
-    "ip": "10.32.113.158",
-    "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-    "mac": "00:50:56:A2:B1:5B",
+    "ip": "10.32.112.130",
+    "ip6": "fe80::e110:a74a:480:4409%4",
+    "mac": "00:50:56:A2:BB:13",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%2",
+    "network6": "fe80::%4",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10",
+  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.10.4",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 15,
-    "seconds": 57509,
-    "uptime": "15:58 hours"
+    "hours": 6,
+    "seconds": 22954,
+    "uptime": "6:22 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:22 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 22954,
+  "virtual": "vmware"
 }

--- a/facts/3.6/windows-2008 r2-x86_64.facts
+++ b/facts/3.6/windows-2008 r2-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.10.4",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 6f a5 43 75 12 ae-15 76 ec 76 47 5d 25 9a"
+      "serial_number": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.6.5",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "RJ2WFCMG7UF17CW\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "HKB7CU8PWYEHS3A\\Administrator"
+    "user": "RJ2WFCMG7UF17CW\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.127.75",
+  "ipaddress6": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress6_Local Area Connection": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress_Local Area Connection": "10.32.127.75",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:06:09",
+  "macaddress_Local Area Connection": "00:50:56:A2:06:09",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
       "available": "2.94 GiB",
-      "available_bytes": 3161042944,
-      "capacity": "26.39%",
+      "available_bytes": 3159089152,
+      "capacity": "26.43%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
       "used": "1.06 GiB",
-      "used_bytes": 1133023232
+      "used_bytes": 1134977024
     }
   },
+  "memoryfree": "2.94 GiB",
+  "memoryfree_mb": 3012.7421875,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.116.113",
+            "address": "10.32.127.75",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::60bc:b13:61bf:9110%12",
+            "address": "fe80::80be:a6bc:1766:4c99%11",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%12"
+            "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.116.113",
-        "ip6": "fe80::60bc:b13:61bf:9110%12",
-        "mac": "00:50:56:A2:C2:80",
+        "ip": "10.32.127.75",
+        "ip6": "fe80::80be:a6bc:1766:4c99%11",
+        "mac": "00:50:56:A2:06:09",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%12"
+        "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.116.113",
-    "ip6": "fe80::60bc:b13:61bf:9110%12",
-    "mac": "00:50:56:A2:C2:80",
+    "ip": "10.32.127.75",
+    "ip6": "fe80::80be:a6bc:1766:4c99%11",
+    "mac": "00:50:56:A2:06:09",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%12",
+    "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008 R2",
+  "operatingsystemrelease": "2008 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.10.4",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 281,
-    "uptime": "0:04 hours"
+    "hours": 16,
+    "seconds": 60223,
+    "uptime": "16:43 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "16:43 hours",
+  "uptime_days": 0,
+  "uptime_hours": 16,
+  "uptime_seconds": 60223,
+  "virtual": "vmware"
 }

--- a/facts/3.6/windows-2008-x86_64.facts
+++ b/facts/3.6/windows-2008-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.10.4",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "Phoenix Technologies LTD",
     "product": {
       "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 3f 06 9e 43 30 eb-b3 f4 58 de 6a 3e e5 9f"
+      "serial_number": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.6.5",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "QFMZ60DYQGU893J\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "D5NOW95YYUDLWEV\\Administrator"
+    "user": "QFMZ60DYQGU893J\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.95",
+  "ipaddress6": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress6_Local Area Connection": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress_Local Area Connection": "10.32.126.95",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.0",
   "kernelrelease": "6.0.6002",
   "kernelversion": "6.0.6002",
+  "macaddress": "00:50:56:A2:E0:07",
+  "macaddress_Local Area Connection": "00:50:56:A2:E0:07",
+  "manufacturer": "Phoenix Technologies LTD",
   "memory": {
     "system": {
-      "available": "3.05 GiB",
-      "available_bytes": 3272323072,
-      "capacity": "23.78%",
+      "available": "3.11 GiB",
+      "available_bytes": 3336269824,
+      "capacity": "22.29%",
       "total": "4.00 GiB",
       "total_bytes": 4293357568,
-      "used": "973.73 MiB",
-      "used_bytes": 1021034496
+      "used": "912.75 MiB",
+      "used_bytes": 957087744
     }
   },
+  "memoryfree": "3.11 GiB",
+  "memoryfree_mb": 3181.71484375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4094.46484375,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%10",
+  "network6_Local Area Connection": "fe80::%10",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.117.107",
+            "address": "10.32.126.95",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::e9c8:8f06:477c:99fa%11",
+            "address": "fe80::dd24:f5a9:347b:c256%10",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%11"
+            "network": "fe80::%10"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.117.107",
-        "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-        "mac": "00:50:56:A2:B1:DA",
+        "ip": "10.32.126.95",
+        "ip6": "fe80::dd24:f5a9:347b:c256%10",
+        "mac": "00:50:56:A2:E0:07",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%11"
+        "network6": "fe80::%10"
       }
     },
-    "ip": "10.32.117.107",
-    "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-    "mac": "00:50:56:A2:B1:DA",
+    "ip": "10.32.126.95",
+    "ip6": "fe80::dd24:f5a9:347b:c256%10",
+    "mac": "00:50:56:A2:E0:07",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%11",
+    "network6": "fe80::%10",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008",
+  "operatingsystemrelease": "2008",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware Virtual Platform",
   "puppetversion": "4.10.4",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 15,
-    "seconds": 54645,
-    "uptime": "15:10 hours"
+    "hours": 13,
+    "seconds": 50263,
+    "uptime": "13:57 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "13:57 hours",
+  "uptime_days": 0,
+  "uptime_hours": 13,
+  "uptime_seconds": 50263,
+  "virtual": "vmware"
 }

--- a/facts/3.6/windows-2012 r2-core-x86_64.facts
+++ b/facts/3.6/windows-2012 r2-core-x86_64.facts
@@ -1,60 +1,92 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.10.4",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
-    "manufacturer": "Phoenix Technologies LTD",
+    "manufacturer": "VMware, Inc.",
     "product": {
-      "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 91 42 5a d1 7a 50-73 d9 8a 73 2a ba e5 d9"
+      "name": "VMware7,1",
+      "serial_number": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.6.5",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "G0ZBZXENEIL32X5\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "GHWYJ7383D7T8XY\\cyg_server"
+    "user": "G0ZBZXENEIL32X5\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.117.89",
+  "ipaddress6": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress6_Ethernet0": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress_Ethernet0": "10.32.117.89",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:72:05",
+  "macaddress_Ethernet0": "00:50:56:A2:72:05",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.97 GiB",
-      "available_bytes": 3186335744,
-      "capacity": "25.80%",
-      "total": "4.00 GiB",
-      "total_bytes": 4294496256,
-      "used": "1.03 GiB",
-      "used_bytes": 1108160512
+      "available": "5.34 GiB",
+      "available_bytes": 5733113856,
+      "capacity": "11.00%",
+      "total": "6.00 GiB",
+      "total_bytes": 6441549824,
+      "used": "675.62 MiB",
+      "used_bytes": 708435968
     }
   },
+  "memoryfree": "5.34 GiB",
+  "memoryfree_mb": 5467.5234375,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
-      "Ethernet": {
+      "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.114.127",
+            "address": "10.32.117.89",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::fd0d:3323:1bb4:680d%12",
+            "address": "fe80::71c4:5555:d38:94fa%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.114.127",
-        "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-        "mac": "00:50:56:A2:34:6A",
+        "ip": "10.32.117.89",
+        "ip6": "fe80::71c4:5555:d38:94fa%12",
+        "mac": "00:50:56:A2:72:05",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,16 +94,19 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.114.127",
-    "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-    "mac": "00:50:56:A2:34:6A",
+    "ip": "10.32.117.89",
+    "ip6": "fe80::71c4:5555:d38:94fa%12",
+    "mac": "00:50:56:A2:72:05",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
     "network6": "fe80::%12",
-    "primary": "Ethernet"
+    "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\pstools;C:\\cygwin64\\bin",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.10.4",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 0,
-    "hours": 11,
-    "seconds": 41411,
-    "uptime": "11:30 hours"
+    "days": 1,
+    "hours": 24,
+    "seconds": 86777,
+    "uptime": "1 day"
   },
-  "timezone": "Pacific Daylight Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "timezone": "Coordinated Universal Time",
+  "uptime": "1 day",
+  "uptime_days": 1,
+  "uptime_hours": 24,
+  "uptime_seconds": 86777,
+  "virtual": "vmware"
 }

--- a/facts/3.6/windows-2012 r2-x86_64.facts
+++ b/facts/3.6/windows-2012 r2-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.10.4",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 f5 c4 62 f1 23 8a-45 87 85 c8 cc 40 99 c5"
+      "serial_number": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.6.5",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GTT427VBINBGPOL\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "QYK15CXKD67BH65\\Administrator"
+    "user": "GTT427VBINBGPOL\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.127.212",
+  "ipaddress6": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress6_Ethernet0": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress_Ethernet0": "10.32.127.212",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:D9:94",
+  "macaddress_Ethernet0": "00:50:56:A2:D9:94",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "5.12 GiB",
-      "available_bytes": 5496426496,
-      "capacity": "14.67%",
+      "available": "5.21 GiB",
+      "available_bytes": 5594238976,
+      "capacity": "13.15%",
       "total": "6.00 GiB",
       "total_bytes": 6441549824,
-      "used": "901.34 MiB",
-      "used_bytes": 945123328
+      "used": "808.06 MiB",
+      "used_bytes": 847310848
     }
   },
+  "memoryfree": "5.21 GiB",
+  "memoryfree_mb": 5335.08203125,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.113.108",
+            "address": "10.32.127.212",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::d432:9626:e5c4:73fa%12",
+            "address": "fe80::a0b5:f374:6703:1ec6%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.108",
-        "ip6": "fe80::d432:9626:e5c4:73fa%12",
-        "mac": "00:50:56:A2:D5:08",
+        "ip": "10.32.127.212",
+        "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+        "mac": "00:50:56:A2:D9:94",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.113.108",
-    "ip6": "fe80::d432:9626:e5c4:73fa%12",
-    "mac": "00:50:56:A2:D5:08",
+    "ip": "10.32.127.212",
+    "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+    "mac": "00:50:56:A2:D9:94",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.10.4",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 3,
-    "seconds": 11968,
-    "uptime": "3:19 hours"
+    "hours": 0,
+    "seconds": 1584,
+    "uptime": "0:26 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "0:26 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 1584,
+  "virtual": "vmware"
 }

--- a/facts/3.6/windows-2012-x86_64.facts
+++ b/facts/3.6/windows-2012-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.10.4",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d0 54 b4 68 27 15-5e 55 a0 aa a1 c4 b6 85"
+      "serial_number": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.6.5",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "WX8QEA42SDYVTT6\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "O1JC0NKUU0IWW8R\\Administrator"
+    "user": "WX8QEA42SDYVTT6\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.136",
+  "ipaddress6": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress6_Ethernet0": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress_Ethernet0": "10.32.112.136",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.2",
   "kernelrelease": "6.2.9200",
   "kernelversion": "6.2.9200",
+  "macaddress": "00:50:56:A2:5B:88",
+  "macaddress_Ethernet0": "00:50:56:A2:5B:88",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.13 GiB",
-      "available_bytes": 3364290560,
-      "capacity": "21.65%",
+      "available": "3.18 GiB",
+      "available_bytes": 3416657920,
+      "capacity": "20.43%",
       "total": "4.00 GiB",
       "total_bytes": 4294062080,
-      "used": "886.70 MiB",
-      "used_bytes": 929771520
+      "used": "836.76 MiB",
+      "used_bytes": 877404160
     }
   },
+  "memoryfree": "3.18 GiB",
+  "memoryfree_mb": 3258.37890625,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.13671875,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.115.189",
+            "address": "10.32.112.136",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::b90b:b82d:cd47:12fc%13",
+            "address": "fe80::256a:cde6:f021:6c49%12",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%13"
+            "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.115.189",
-        "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-        "mac": "00:50:56:A2:92:62",
+        "ip": "10.32.112.136",
+        "ip6": "fe80::256a:cde6:f021:6c49%12",
+        "mac": "00:50:56:A2:5B:88",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%13"
+        "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.115.189",
-    "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-    "mac": "00:50:56:A2:92:62",
+    "ip": "10.32.112.136",
+    "ip6": "fe80::256a:cde6:f021:6c49%12",
+    "mac": "00:50:56:A2:5B:88",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%13",
+    "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012",
+  "operatingsystemrelease": "2012",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.10.4",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 12,
-    "seconds": 46464,
-    "uptime": "12:54 hours"
+    "hours": 15,
+    "seconds": 54589,
+    "uptime": "15:09 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "15:09 hours",
+  "uptime_days": 0,
+  "uptime_hours": 15,
+  "uptime_seconds": 54589,
+  "virtual": "vmware"
 }

--- a/facts/3.6/windows-2016-x86_64.facts
+++ b/facts/3.6/windows-2016-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.10.4",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d8 fb 34 7b b4 e8-dd 91 bd ef cc 32 1e 6c"
+      "serial_number": "VMware-42 22 28 b9 e9 7f 7e ac-48 14 76 dc f2 42 91 47"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.6.5",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GR3WVWP2B63LSOM\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "IHGAJGT1OU8FTDM\\Administrator"
+    "user": "GR3WVWP2B63LSOM\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.60",
+  "ipaddress6": "fe80::48:3cd:d72:aa17%5",
+  "ipaddress6_Ethernet0": "fe80::48:3cd:d72:aa17%5",
+  "ipaddress_Ethernet0": "10.32.125.60",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:38:BE",
+  "macaddress_Ethernet0": "00:50:56:A2:38:BE",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.93 GiB",
-      "available_bytes": 3150303232,
-      "capacity": "26.64%",
+      "available": "2.90 GiB",
+      "available_bytes": 3112415232,
+      "capacity": "27.52%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "1.07 GiB",
-      "used_bytes": 1143754752
+      "used": "1.10 GiB",
+      "used_bytes": 1181642752
     }
   },
+  "memoryfree": "2.90 GiB",
+  "memoryfree_mb": 2968.23046875,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%5",
+  "network6_Ethernet0": "fe80::%5",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.119.232",
+            "address": "10.32.125.60",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::99c3:c512:bd3:5f63%3",
+            "address": "fe80::48:3cd:d72:aa17%5",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%3"
+            "network": "fe80::%5"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.119.232",
-        "ip6": "fe80::99c3:c512:bd3:5f63%3",
-        "mac": "00:50:56:A2:68:15",
+        "ip": "10.32.125.60",
+        "ip6": "fe80::48:3cd:d72:aa17%5",
+        "mac": "00:50:56:A2:38:BE",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%3"
+        "network6": "fe80::%5"
       }
     },
-    "ip": "10.32.119.232",
-    "ip6": "fe80::99c3:c512:bd3:5f63%3",
-    "mac": "00:50:56:A2:68:15",
+    "ip": "10.32.125.60",
+    "ip6": "fe80::48:3cd:d72:aa17%5",
+    "mac": "00:50:56:A2:38:BE",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%3",
+    "network6": "fe80::%5",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2016",
+  "operatingsystemrelease": "2016",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.10.4",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 28 b9 e9 7f 7e ac-48 14 76 dc f2 42 91 47",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 1,
-    "seconds": 4584,
-    "uptime": "1:16 hours"
+    "hours": 8,
+    "seconds": 29671,
+    "uptime": "8:14 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "uptime": "8:14 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29671,
+  "virtual": "vmware"
 }

--- a/facts/3.6/windows-7-x86_64.facts
+++ b/facts/3.6/windows-7-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.10.4",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 a6 6f 63 84 0d 53-07 bc 72 79 02 59 33 7a"
+      "serial_number": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.6.5",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "N6IFGFZXW976ITI\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "G089LVS4X1ERMNM\\Administrator"
+    "user": "N6IFGFZXW976ITI\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.90",
+  "ipaddress6": "fe80::2121:2899:8986:e379%11",
+  "ipaddress6_Local Area Connection": "fe80::2121:2899:8986:e379%11",
+  "ipaddress_Local Area Connection": "10.32.126.90",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:78:83",
+  "macaddress_Local Area Connection": "00:50:56:A2:78:83",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.89 GiB",
-      "available_bytes": 3106488320,
-      "capacity": "27.66%",
+      "available": "2.95 GiB",
+      "available_bytes": 3170254848,
+      "capacity": "26.17%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.11 GiB",
-      "used_bytes": 1187577856
+      "used": "1.05 GiB",
+      "used_bytes": 1123811328
     }
   },
+  "memoryfree": "2.95 GiB",
+  "memoryfree_mb": 3023.390625,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.126.73",
+            "address": "10.32.126.90",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::b4bd:32dd:a5c:f8a%12",
+            "address": "fe80::2121:2899:8986:e379%11",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%12"
+            "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.126.73",
-        "ip6": "fe80::b4bd:32dd:a5c:f8a%12",
-        "mac": "00:50:56:A2:EF:51",
+        "ip": "10.32.126.90",
+        "ip6": "fe80::2121:2899:8986:e379%11",
+        "mac": "00:50:56:A2:78:83",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%12"
+        "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.126.73",
-    "ip6": "fe80::b4bd:32dd:a5c:f8a%12",
-    "mac": "00:50:56:A2:EF:51",
+    "ip": "10.32.126.90",
+    "ip6": "fe80::2121:2899:8986:e379%11",
+    "mac": "00:50:56:A2:78:83",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%12",
+    "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "7",
+  "operatingsystemrelease": "7",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.10.4",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 16,
-    "seconds": 58791,
-    "uptime": "16:19 hours"
+    "hours": 8,
+    "seconds": 29237,
+    "uptime": "8:07 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "8:07 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29237,
+  "virtual": "vmware"
 }

--- a/facts/3.6/windows-8.1-x86_64.facts
+++ b/facts/3.6/windows-8.1-x86_64.facts
@@ -1,37 +1,69 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "1.10.4",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 0f 99 71 37 c9 34 5c-60 e2 5f ad 59 28 d7 53"
+      "serial_number": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.6.5",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "B5GMZC25YP3WRFT\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "TGPX4C0ZOVOW6AL\\Administrator"
+    "user": "B5GMZC25YP3WRFT\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.84",
+  "ipaddress6": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress6_Ethernet0": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress_Ethernet0": "10.32.125.84",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:FD:34",
+  "macaddress_Ethernet0": "00:50:56:A2:FD:34",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.51 GiB",
-      "available_bytes": 2693271552,
-      "capacity": "37.28%",
+      "available": "2.42 GiB",
+      "available_bytes": 2602627072,
+      "capacity": "39.39%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.49 GiB",
-      "used_bytes": 1600794624
+      "used": "1.58 GiB",
+      "used_bytes": 1691439104
     }
   },
+  "memoryfree": "2.42 GiB",
+  "memoryfree_mb": 2482.05859375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
-    "dhcp": "10.32.22.9",
+    "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.126.10",
+            "address": "10.32.125.84",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::d9b6:d8a2:98e1:bcf0%3",
+            "address": "fe80::e490:85dc:9a71:4d9e%3",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%3"
           }
         ],
-        "dhcp": "10.32.22.9",
-        "ip": "10.32.126.10",
-        "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-        "mac": "00:50:56:8F:42:E3",
+        "dhcp": "10.32.22.10",
+        "ip": "10.32.125.84",
+        "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+        "mac": "00:50:56:A2:FD:34",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.126.10",
-    "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-    "mac": "00:50:56:8F:42:E3",
+    "ip": "10.32.125.84",
+    "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+    "mac": "00:50:56:A2:FD:34",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "8.1",
+  "operatingsystemrelease": "8.1",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "4.10.4",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
     "version": "2.1.9"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "serialnumber": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 11,
-    "hours": 275,
-    "seconds": 992801,
-    "uptime": "11 days"
+    "days": 0,
+    "hours": 18,
+    "seconds": 66475,
+    "uptime": "18:27 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "18:27 hours",
+  "uptime_days": 0,
+  "uptime_hours": 18,
+  "uptime_seconds": 66475,
+  "virtual": "vmware"
 }

--- a/facts/3.7/windows-10-i386.facts
+++ b/facts/3.7/windows-10-i386.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.0.1",
+  "architecture": "x86",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 ca fe f0 e7 64 ba-7e c1 ac 81 ec 79 2a c9"
+      "serial_number": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.7.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "i686",
+  "hostname": "foo",
+  "id": "CAYR11ES3BMJ6UG\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "CD9O9NMEXAPI3GF\\Administrator"
+    "user": "CAYR11ES3BMJ6UG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.121.213",
+  "ipaddress6": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress6_Ethernet0": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress_Ethernet0": "10.32.121.213",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:72:55",
+  "macaddress_Ethernet0": "00:50:56:A2:72:55",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "1.94 GiB",
-      "available_bytes": 2078420992,
-      "capacity": "35.46%",
+      "available": "1.86 GiB",
+      "available_bytes": 2000003072,
+      "capacity": "37.89%",
       "total": "3.00 GiB",
       "total_bytes": 3220324352,
-      "used": "1.06 GiB",
-      "used_bytes": 1141903360
+      "used": "1.14 GiB",
+      "used_bytes": 1220321280
     }
   },
+  "memoryfree": "1.86 GiB",
+  "memoryfree_mb": 1907.3515625,
+  "memorysize": "3.00 GiB",
+  "memorysize_mb": 3071.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.120.121",
+            "address": "10.32.121.213",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::45d7:5af5:8f53:8392%5",
+            "address": "fe80::4dab:3df1:6f45:ee04%3",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%5"
+            "network": "fe80::%3"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.120.121",
-        "ip6": "fe80::45d7:5af5:8f53:8392%5",
-        "mac": "00:50:56:A2:D4:F1",
+        "ip": "10.32.121.213",
+        "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+        "mac": "00:50:56:A2:72:55",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%5"
+        "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.120.121",
-    "ip6": "fe80::45d7:5af5:8f53:8392%5",
-    "mac": "00:50:56:A2:D4:F1",
+    "ip": "10.32.121.213",
+    "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+    "mac": "00:50:56:A2:72:55",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%5",
+    "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10",
+  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x86",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.0.1",
   "ruby": {
     "platform": "i386-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "i386-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 698,
-    "uptime": "0:11 hours"
+    "hours": 6,
+    "seconds": 23030,
+    "uptime": "6:23 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:23 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 23030,
+  "virtual": "vmware"
 }

--- a/facts/3.7/windows-10-x86_64.facts
+++ b/facts/3.7/windows-10-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.0.1",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 b9 12 ec 3b 6e ab-61 61 29 cf f4 72 99 c3"
+      "serial_number": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.7.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "V46YN43Q8ZY3NYG\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "PQX8SDC5TGXO8LI\\Administrator"
+    "user": "V46YN43Q8ZY3NYG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.130",
+  "ipaddress6": "fe80::e110:a74a:480:4409%4",
+  "ipaddress6_Ethernet0": "fe80::e110:a74a:480:4409%4",
+  "ipaddress_Ethernet0": "10.32.112.130",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:BB:13",
+  "macaddress_Ethernet0": "00:50:56:A2:BB:13",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.74 GiB",
-      "available_bytes": 2938097664,
-      "capacity": "31.58%",
+      "available": "2.66 GiB",
+      "available_bytes": 2859622400,
+      "capacity": "33.41%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "1.26 GiB",
-      "used_bytes": 1355960320
+      "used": "1.34 GiB",
+      "used_bytes": 1434435584
     }
   },
+  "memoryfree": "2.66 GiB",
+  "memoryfree_mb": 2727.1484375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%4",
+  "network6_Ethernet0": "fe80::%4",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.113.158",
+            "address": "10.32.112.130",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::753c:44f6:3bb1:cb0c%2",
+            "address": "fe80::e110:a74a:480:4409%4",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%2"
+            "network": "fe80::%4"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.158",
-        "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-        "mac": "00:50:56:A2:B1:5B",
+        "ip": "10.32.112.130",
+        "ip6": "fe80::e110:a74a:480:4409%4",
+        "mac": "00:50:56:A2:BB:13",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%2"
+        "network6": "fe80::%4"
       }
     },
-    "ip": "10.32.113.158",
-    "ip6": "fe80::753c:44f6:3bb1:cb0c%2",
-    "mac": "00:50:56:A2:B1:5B",
+    "ip": "10.32.112.130",
+    "ip6": "fe80::e110:a74a:480:4409%4",
+    "mac": "00:50:56:A2:BB:13",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%2",
+    "network6": "fe80::%4",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10",
+  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.0.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 15,
-    "seconds": 57425,
-    "uptime": "15:57 hours"
+    "hours": 6,
+    "seconds": 22876,
+    "uptime": "6:21 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:21 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 22876,
+  "virtual": "vmware"
 }

--- a/facts/3.7/windows-2008 r2-x86_64.facts
+++ b/facts/3.7/windows-2008 r2-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.0.1",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 6f a5 43 75 12 ae-15 76 ec 76 47 5d 25 9a"
+      "serial_number": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.7.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "RJ2WFCMG7UF17CW\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "HKB7CU8PWYEHS3A\\Administrator"
+    "user": "RJ2WFCMG7UF17CW\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.127.75",
+  "ipaddress6": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress6_Local Area Connection": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress_Local Area Connection": "10.32.127.75",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:06:09",
+  "macaddress_Local Area Connection": "00:50:56:A2:06:09",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.05 GiB",
-      "available_bytes": 3276099584,
-      "capacity": "23.71%",
+      "available": "3.02 GiB",
+      "available_bytes": 3241771008,
+      "capacity": "24.51%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "970.81 MiB",
-      "used_bytes": 1017966592
+      "used": "1003.55 MiB",
+      "used_bytes": 1052295168
     }
   },
+  "memoryfree": "3.02 GiB",
+  "memoryfree_mb": 3091.59375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.116.113",
+            "address": "10.32.127.75",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::60bc:b13:61bf:9110%12",
+            "address": "fe80::80be:a6bc:1766:4c99%11",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%12"
+            "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.116.113",
-        "ip6": "fe80::60bc:b13:61bf:9110%12",
-        "mac": "00:50:56:A2:C2:80",
+        "ip": "10.32.127.75",
+        "ip6": "fe80::80be:a6bc:1766:4c99%11",
+        "mac": "00:50:56:A2:06:09",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%12"
+        "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.116.113",
-    "ip6": "fe80::60bc:b13:61bf:9110%12",
-    "mac": "00:50:56:A2:C2:80",
+    "ip": "10.32.127.75",
+    "ip6": "fe80::80be:a6bc:1766:4c99%11",
+    "mac": "00:50:56:A2:06:09",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%12",
+    "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008 R2",
+  "operatingsystemrelease": "2008 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.0.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 202,
-    "uptime": "0:03 hours"
+    "hours": 16,
+    "seconds": 60152,
+    "uptime": "16:42 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "16:42 hours",
+  "uptime_days": 0,
+  "uptime_hours": 16,
+  "uptime_seconds": 60152,
+  "virtual": "vmware"
 }

--- a/facts/3.7/windows-2008-x86_64.facts
+++ b/facts/3.7/windows-2008-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.0.1",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "Phoenix Technologies LTD",
     "product": {
       "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 3f 06 9e 43 30 eb-b3 f4 58 de 6a 3e e5 9f"
+      "serial_number": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.7.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "QFMZ60DYQGU893J\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "D5NOW95YYUDLWEV\\Administrator"
+    "user": "QFMZ60DYQGU893J\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.95",
+  "ipaddress6": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress6_Local Area Connection": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress_Local Area Connection": "10.32.126.95",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.0",
   "kernelrelease": "6.0.6002",
   "kernelversion": "6.0.6002",
+  "macaddress": "00:50:56:A2:E0:07",
+  "macaddress_Local Area Connection": "00:50:56:A2:E0:07",
+  "manufacturer": "Phoenix Technologies LTD",
   "memory": {
     "system": {
-      "available": "3.11 GiB",
-      "available_bytes": 3340189696,
-      "capacity": "22.20%",
+      "available": "3.12 GiB",
+      "available_bytes": 3354456064,
+      "capacity": "21.87%",
       "total": "4.00 GiB",
       "total_bytes": 4293357568,
-      "used": "909.01 MiB",
-      "used_bytes": 953167872
+      "used": "895.41 MiB",
+      "used_bytes": 938901504
     }
   },
+  "memoryfree": "3.12 GiB",
+  "memoryfree_mb": 3199.05859375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4094.46484375,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%10",
+  "network6_Local Area Connection": "fe80::%10",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.117.107",
+            "address": "10.32.126.95",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::e9c8:8f06:477c:99fa%11",
+            "address": "fe80::dd24:f5a9:347b:c256%10",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%11"
+            "network": "fe80::%10"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.117.107",
-        "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-        "mac": "00:50:56:A2:B1:DA",
+        "ip": "10.32.126.95",
+        "ip6": "fe80::dd24:f5a9:347b:c256%10",
+        "mac": "00:50:56:A2:E0:07",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%11"
+        "network6": "fe80::%10"
       }
     },
-    "ip": "10.32.117.107",
-    "ip6": "fe80::e9c8:8f06:477c:99fa%11",
-    "mac": "00:50:56:A2:B1:DA",
+    "ip": "10.32.126.95",
+    "ip6": "fe80::dd24:f5a9:347b:c256%10",
+    "mac": "00:50:56:A2:E0:07",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%11",
+    "network6": "fe80::%10",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008",
+  "operatingsystemrelease": "2008",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware Virtual Platform",
   "puppetversion": "5.0.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 15,
-    "seconds": 54495,
-    "uptime": "15:08 hours"
+    "hours": 13,
+    "seconds": 50101,
+    "uptime": "13:55 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "13:55 hours",
+  "uptime_days": 0,
+  "uptime_hours": 13,
+  "uptime_seconds": 50101,
+  "virtual": "vmware"
 }

--- a/facts/3.7/windows-2012 r2-core-x86_64.facts
+++ b/facts/3.7/windows-2012 r2-core-x86_64.facts
@@ -1,60 +1,92 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.0.1",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
-    "manufacturer": "Phoenix Technologies LTD",
+    "manufacturer": "VMware, Inc.",
     "product": {
-      "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 91 42 5a d1 7a 50-73 d9 8a 73 2a ba e5 d9"
+      "name": "VMware7,1",
+      "serial_number": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.7.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "G0ZBZXENEIL32X5\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "GHWYJ7383D7T8XY\\cyg_server"
+    "user": "G0ZBZXENEIL32X5\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.117.89",
+  "ipaddress6": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress6_Ethernet0": "fe80::71c4:5555:d38:94fa%12",
+  "ipaddress_Ethernet0": "10.32.117.89",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:72:05",
+  "macaddress_Ethernet0": "00:50:56:A2:72:05",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.07 GiB",
-      "available_bytes": 3297034240,
-      "capacity": "23.23%",
-      "total": "4.00 GiB",
-      "total_bytes": 4294496256,
-      "used": "951.25 MiB",
-      "used_bytes": 997462016
+      "available": "5.36 GiB",
+      "available_bytes": 5758328832,
+      "capacity": "10.61%",
+      "total": "6.00 GiB",
+      "total_bytes": 6441549824,
+      "used": "651.57 MiB",
+      "used_bytes": 683220992
     }
   },
+  "memoryfree": "5.36 GiB",
+  "memoryfree_mb": 5491.5703125,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
     "interfaces": {
-      "Ethernet": {
+      "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.114.127",
+            "address": "10.32.117.89",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::fd0d:3323:1bb4:680d%12",
+            "address": "fe80::71c4:5555:d38:94fa%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.114.127",
-        "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-        "mac": "00:50:56:A2:34:6A",
+        "ip": "10.32.117.89",
+        "ip6": "fe80::71c4:5555:d38:94fa%12",
+        "mac": "00:50:56:A2:72:05",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,16 +94,19 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.114.127",
-    "ip6": "fe80::fd0d:3323:1bb4:680d%12",
-    "mac": "00:50:56:A2:34:6A",
+    "ip": "10.32.117.89",
+    "ip6": "fe80::71c4:5555:d38:94fa%12",
+    "mac": "00:50:56:A2:72:05",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
     "network6": "fe80::%12",
-    "primary": "Ethernet"
+    "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\pstools;C:\\cygwin64\\bin",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.0.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 39 4c 25 b1 0c 61-6c 43 06 31 15 f9 d3 79",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 0,
-    "hours": 11,
-    "seconds": 41345,
-    "uptime": "11:29 hours"
+    "days": 1,
+    "hours": 24,
+    "seconds": 86699,
+    "uptime": "1 day"
   },
-  "timezone": "Pacific Daylight Time",
-  "virtual": "vmware",
-  "hostname": "foo",
-  "domain": "example.com",
-  "fqdn": "foo.example.com"
+  "timezone": "Coordinated Universal Time",
+  "uptime": "1 day",
+  "uptime_days": 1,
+  "uptime_hours": 24,
+  "uptime_seconds": 86699,
+  "virtual": "vmware"
 }

--- a/facts/3.7/windows-2012 r2-x86_64.facts
+++ b/facts/3.7/windows-2012 r2-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.0.1",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 f5 c4 62 f1 23 8a-45 87 85 c8 cc 40 99 c5"
+      "serial_number": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.7.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GTT427VBINBGPOL\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "QYK15CXKD67BH65\\Administrator"
+    "user": "GTT427VBINBGPOL\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.127.212",
+  "ipaddress6": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress6_Ethernet0": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress_Ethernet0": "10.32.127.212",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:D9:94",
+  "macaddress_Ethernet0": "00:50:56:A2:D9:94",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "5.20 GiB",
-      "available_bytes": 5584609280,
-      "capacity": "13.30%",
+      "available": "5.22 GiB",
+      "available_bytes": 5600530432,
+      "capacity": "13.06%",
       "total": "6.00 GiB",
       "total_bytes": 6441549824,
-      "used": "817.24 MiB",
-      "used_bytes": 856940544
+      "used": "802.06 MiB",
+      "used_bytes": 841019392
     }
   },
+  "memoryfree": "5.22 GiB",
+  "memoryfree_mb": 5341.08203125,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.113.108",
+            "address": "10.32.127.212",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::d432:9626:e5c4:73fa%12",
+            "address": "fe80::a0b5:f374:6703:1ec6%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.108",
-        "ip6": "fe80::d432:9626:e5c4:73fa%12",
-        "mac": "00:50:56:A2:D5:08",
+        "ip": "10.32.127.212",
+        "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+        "mac": "00:50:56:A2:D9:94",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.113.108",
-    "ip6": "fe80::d432:9626:e5c4:73fa%12",
-    "mac": "00:50:56:A2:D5:08",
+    "ip": "10.32.127.212",
+    "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+    "mac": "00:50:56:A2:D9:94",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.0.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 3,
-    "seconds": 11907,
-    "uptime": "3:18 hours"
+    "hours": 0,
+    "seconds": 1519,
+    "uptime": "0:25 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "0:25 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 1519,
+  "virtual": "vmware"
 }

--- a/facts/3.7/windows-2012-x86_64.facts
+++ b/facts/3.7/windows-2012-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.0.1",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 d0 54 b4 68 27 15-5e 55 a0 aa a1 c4 b6 85"
+      "serial_number": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.7.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "WX8QEA42SDYVTT6\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "O1JC0NKUU0IWW8R\\Administrator"
+    "user": "WX8QEA42SDYVTT6\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.136",
+  "ipaddress6": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress6_Ethernet0": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress_Ethernet0": "10.32.112.136",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.2",
   "kernelrelease": "6.2.9200",
   "kernelversion": "6.2.9200",
+  "macaddress": "00:50:56:A2:5B:88",
+  "macaddress_Ethernet0": "00:50:56:A2:5B:88",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.23 GiB",
-      "available_bytes": 3464278016,
-      "capacity": "19.32%",
+      "available": "3.26 GiB",
+      "available_bytes": 3504914432,
+      "capacity": "18.38%",
       "total": "4.00 GiB",
       "total_bytes": 4294062080,
-      "used": "791.34 MiB",
-      "used_bytes": 829784064
+      "used": "752.59 MiB",
+      "used_bytes": 789147648
     }
   },
+  "memoryfree": "3.26 GiB",
+  "memoryfree_mb": 3342.546875,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.13671875,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.115.189",
+            "address": "10.32.112.136",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::b90b:b82d:cd47:12fc%13",
+            "address": "fe80::256a:cde6:f021:6c49%12",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%13"
+            "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.115.189",
-        "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-        "mac": "00:50:56:A2:92:62",
+        "ip": "10.32.112.136",
+        "ip6": "fe80::256a:cde6:f021:6c49%12",
+        "mac": "00:50:56:A2:5B:88",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%13"
+        "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.115.189",
-    "ip6": "fe80::b90b:b82d:cd47:12fc%13",
-    "mac": "00:50:56:A2:92:62",
+    "ip": "10.32.112.136",
+    "ip6": "fe80::256a:cde6:f021:6c49%12",
+    "mac": "00:50:56:A2:5B:88",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%13",
+    "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012",
+  "operatingsystemrelease": "2012",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.0.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 12,
-    "seconds": 46400,
-    "uptime": "12:53 hours"
+    "hours": 15,
+    "seconds": 54529,
+    "uptime": "15:08 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "15:08 hours",
+  "uptime_days": 0,
+  "uptime_hours": 15,
+  "uptime_seconds": 54529,
+  "virtual": "vmware"
 }

--- a/facts/3.7/windows-2016-x86_64.facts
+++ b/facts/3.7/windows-2016-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.0.1",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 b2 44 67 3a 83 5c-ac a9 00 ba c9 60 d6 e8"
+      "serial_number": "VMware-42 22 28 b9 e9 7f 7e ac-48 14 76 dc f2 42 91 47"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.7.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GR3WVWP2B63LSOM\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "HDWU2FYUKPC0CPW\\Administrator"
+    "user": "GR3WVWP2B63LSOM\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.60",
+  "ipaddress6": "fe80::48:3cd:d72:aa17%5",
+  "ipaddress6_Ethernet0": "fe80::48:3cd:d72:aa17%5",
+  "ipaddress_Ethernet0": "10.32.125.60",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:38:BE",
+  "macaddress_Ethernet0": "00:50:56:A2:38:BE",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.90 GiB",
-      "available_bytes": 3118796800,
-      "capacity": "27.37%",
+      "available": "2.92 GiB",
+      "available_bytes": 3133460480,
+      "capacity": "27.03%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "1.09 GiB",
-      "used_bytes": 1175261184
+      "used": "1.08 GiB",
+      "used_bytes": 1160597504
     }
   },
+  "memoryfree": "2.92 GiB",
+  "memoryfree_mb": 2988.30078125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%5",
+  "network6_Ethernet0": "fe80::%5",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.116.103",
+            "address": "10.32.125.60",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::2971:1b12:c85e:1970%4",
+            "address": "fe80::48:3cd:d72:aa17%5",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%4"
+            "network": "fe80::%5"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.116.103",
-        "ip6": "fe80::2971:1b12:c85e:1970%4",
-        "mac": "00:50:56:A2:EB:26",
+        "ip": "10.32.125.60",
+        "ip6": "fe80::48:3cd:d72:aa17%5",
+        "mac": "00:50:56:A2:38:BE",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%4"
+        "network6": "fe80::%5"
       }
     },
-    "ip": "10.32.116.103",
-    "ip6": "fe80::2971:1b12:c85e:1970%4",
-    "mac": "00:50:56:A2:EB:26",
+    "ip": "10.32.125.60",
+    "ip6": "fe80::48:3cd:d72:aa17%5",
+    "mac": "00:50:56:A2:38:BE",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%4",
+    "network6": "fe80::%5",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2016",
+  "operatingsystemrelease": "2016",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.0.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 28 b9 e9 7f 7e ac-48 14 76 dc f2 42 91 47",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 0,
-    "seconds": 2121,
-    "uptime": "0:35 hours"
+    "hours": 8,
+    "seconds": 29577,
+    "uptime": "8:12 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "8:12 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29577,
+  "virtual": "vmware"
 }

--- a/facts/3.7/windows-7-x86_64.facts
+++ b/facts/3.7/windows-7-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.0.1",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 a6 6f 63 84 0d 53-07 bc 72 79 02 59 33 7a"
+      "serial_number": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.7.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "N6IFGFZXW976ITI\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "G089LVS4X1ERMNM\\Administrator"
+    "user": "N6IFGFZXW976ITI\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.90",
+  "ipaddress6": "fe80::2121:2899:8986:e379%11",
+  "ipaddress6_Local Area Connection": "fe80::2121:2899:8986:e379%11",
+  "ipaddress_Local Area Connection": "10.32.126.90",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:78:83",
+  "macaddress_Local Area Connection": "00:50:56:A2:78:83",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.97 GiB",
-      "available_bytes": 3187372032,
-      "capacity": "25.77%",
+      "available": "2.98 GiB",
+      "available_bytes": 3200524288,
+      "capacity": "25.47%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.03 GiB",
-      "used_bytes": 1106694144
+      "used": "1.02 GiB",
+      "used_bytes": 1093541888
     }
   },
+  "memoryfree": "2.98 GiB",
+  "memoryfree_mb": 3052.2578125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.126.73",
+            "address": "10.32.126.90",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::b4bd:32dd:a5c:f8a%12",
+            "address": "fe80::2121:2899:8986:e379%11",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%12"
+            "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.126.73",
-        "ip6": "fe80::b4bd:32dd:a5c:f8a%12",
-        "mac": "00:50:56:A2:EF:51",
+        "ip": "10.32.126.90",
+        "ip6": "fe80::2121:2899:8986:e379%11",
+        "mac": "00:50:56:A2:78:83",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%12"
+        "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.126.73",
-    "ip6": "fe80::b4bd:32dd:a5c:f8a%12",
-    "mac": "00:50:56:A2:EF:51",
+    "ip": "10.32.126.90",
+    "ip6": "fe80::2121:2899:8986:e379%11",
+    "mac": "00:50:56:A2:78:83",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%12",
+    "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "7",
+  "operatingsystemrelease": "7",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.0.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 16,
-    "seconds": 58710,
-    "uptime": "16:18 hours"
+    "hours": 8,
+    "seconds": 29161,
+    "uptime": "8:06 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "8:06 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29161,
+  "virtual": "vmware"
 }

--- a/facts/3.7/windows-8.1-x86_64.facts
+++ b/facts/3.7/windows-8.1-x86_64.facts
@@ -1,37 +1,69 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.0.1",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 0f 99 71 37 c9 34 5c-60 e2 5f ad 59 28 d7 53"
+      "serial_number": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.7.1",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "B5GMZC25YP3WRFT\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "TGPX4C0ZOVOW6AL\\Administrator"
+    "user": "B5GMZC25YP3WRFT\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.84",
+  "ipaddress6": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress6_Ethernet0": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress_Ethernet0": "10.32.125.84",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:FD:34",
+  "macaddress_Ethernet0": "00:50:56:A2:FD:34",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.53 GiB",
-      "available_bytes": 2716286976,
-      "capacity": "36.74%",
+      "available": "2.42 GiB",
+      "available_bytes": 2602541056,
+      "capacity": "39.39%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.47 GiB",
-      "used_bytes": 1577779200
+      "used": "1.58 GiB",
+      "used_bytes": 1691525120
     }
   },
+  "memoryfree": "2.42 GiB",
+  "memoryfree_mb": 2481.9765625,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
-    "dhcp": "10.32.22.9",
+    "dhcp": "10.32.22.10",
     "domain": "example.com",
     "fqdn": "foo.example.com",
     "hostname": "foo",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.126.10",
+            "address": "10.32.125.84",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::d9b6:d8a2:98e1:bcf0%3",
+            "address": "fe80::e490:85dc:9a71:4d9e%3",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%3"
           }
         ],
-        "dhcp": "10.32.22.9",
-        "ip": "10.32.126.10",
-        "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-        "mac": "00:50:56:8F:42:E3",
+        "dhcp": "10.32.22.10",
+        "ip": "10.32.125.84",
+        "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+        "mac": "00:50:56:A2:FD:34",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.126.10",
-    "ip6": "fe80::d9b6:d8a2:98e1:bcf0%3",
-    "mac": "00:50:56:8F:42:E3",
+    "ip": "10.32.125.84",
+    "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+    "mac": "00:50:56:A2:FD:34",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "8.1",
+  "operatingsystemrelease": "8.1",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.0.1",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 11,
-    "hours": 275,
-    "seconds": 992721,
-    "uptime": "11 days"
+    "days": 0,
+    "hours": 18,
+    "seconds": 66402,
+    "uptime": "18:26 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "18:26 hours",
+  "uptime_days": 0,
+  "uptime_hours": 18,
+  "uptime_seconds": 66402,
+  "virtual": "vmware"
 }

--- a/facts/3.8/windows-10-i386.facts
+++ b/facts/3.8/windows-10-i386.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.1.0",
+  "architecture": "x86",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 e0 82 d9 6c 6c 07-fc d6 ca 0c 19 2c 0e 5f"
+      "serial_number": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.8.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "i686",
+  "hostname": "foo",
+  "id": "CAYR11ES3BMJ6UG\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "VM8U0UYJYDG3VTG\\Administrator"
+    "user": "CAYR11ES3BMJ6UG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.121.213",
+  "ipaddress6": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress6_Ethernet0": "fe80::4dab:3df1:6f45:ee04%3",
+  "ipaddress_Ethernet0": "10.32.121.213",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:72:55",
+  "macaddress_Ethernet0": "00:50:56:A2:72:55",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "1.89 GiB",
-      "available_bytes": 2026680320,
-      "capacity": "37.07%",
+      "available": "1.88 GiB",
+      "available_bytes": 2019782656,
+      "capacity": "37.28%",
       "total": "3.00 GiB",
       "total_bytes": 3220324352,
-      "used": "1.11 GiB",
-      "used_bytes": 1193644032
+      "used": "1.12 GiB",
+      "used_bytes": 1200541696
     }
   },
+  "memoryfree": "1.88 GiB",
+  "memoryfree_mb": 1926.21484375,
+  "memorysize": "3.00 GiB",
+  "memorysize_mb": 3071.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.124.201",
+            "address": "10.32.121.213",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::ad96:63fe:fb68:a7b1%2",
+            "address": "fe80::4dab:3df1:6f45:ee04%3",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%2"
+            "network": "fe80::%3"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.124.201",
-        "ip6": "fe80::ad96:63fe:fb68:a7b1%2",
-        "mac": "00:50:56:A2:9A:D5",
+        "ip": "10.32.121.213",
+        "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+        "mac": "00:50:56:A2:72:55",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%2"
+        "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.124.201",
-    "ip6": "fe80::ad96:63fe:fb68:a7b1%2",
-    "mac": "00:50:56:A2:9A:D5",
+    "ip": "10.32.121.213",
+    "ip6": "fe80::4dab:3df1:6f45:ee04%3",
+    "mac": "00:50:56:A2:72:55",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%2",
+    "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10",
+  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x86",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.1.0",
   "ruby": {
     "platform": "i386-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "i386-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 8b 0c c8 88 d8 af-8e cf 3e 76 dd 8d 8d bc",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 5,
-    "seconds": 19169,
-    "uptime": "5:19 hours"
+    "hours": 6,
+    "seconds": 22944,
+    "uptime": "6:22 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:22 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 22944,
+  "virtual": "vmware"
 }

--- a/facts/3.8/windows-10-x86_64.facts
+++ b/facts/3.8/windows-10-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.1.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 96 a4 87 8c 3f 48-58 c7 a7 cf db c8 fb f0"
+      "serial_number": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.8.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "V46YN43Q8ZY3NYG\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "CONIRHWW0VSHU49\\Administrator"
+    "user": "V46YN43Q8ZY3NYG\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.130",
+  "ipaddress6": "fe80::e110:a74a:480:4409%4",
+  "ipaddress6_Ethernet0": "fe80::e110:a74a:480:4409%4",
+  "ipaddress_Ethernet0": "10.32.112.130",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:BB:13",
+  "macaddress_Ethernet0": "00:50:56:A2:BB:13",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.70 GiB",
-      "available_bytes": 2897846272,
-      "capacity": "32.51%",
+      "available": "2.64 GiB",
+      "available_bytes": 2836815872,
+      "capacity": "33.94%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "1.30 GiB",
-      "used_bytes": 1396211712
+      "used": "1.36 GiB",
+      "used_bytes": 1457242112
     }
   },
+  "memoryfree": "2.64 GiB",
+  "memoryfree_mb": 2705.3984375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%4",
+  "network6_Ethernet0": "fe80::%4",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,39 +71,42 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.113.13",
+            "address": "10.32.112.130",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::993c:c35f:10f2:9950%5",
+            "address": "fe80::e110:a74a:480:4409%4",
             "netmask": "ffff:ffff:ffff:ffff::",
-            "network": "fe80::%5"
+            "network": "fe80::%4"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.113.13",
-        "ip6": "fe80::993c:c35f:10f2:9950%5",
-        "mac": "00:50:56:A2:FF:1A",
+        "ip": "10.32.112.130",
+        "ip6": "fe80::e110:a74a:480:4409%4",
+        "mac": "00:50:56:A2:BB:13",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
         "network": "10.32.112.0",
-        "network6": "fe80::%5"
+        "network6": "fe80::%4"
       }
     },
-    "ip": "10.32.113.13",
-    "ip6": "fe80::993c:c35f:10f2:9950%5",
-    "mac": "00:50:56:A2:FF:1A",
+    "ip": "10.32.112.130",
+    "ip6": "fe80::e110:a74a:480:4409%4",
+    "mac": "00:50:56:A2:BB:13",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
     "network": "10.32.112.0",
-    "network6": "fe80::%5",
+    "network6": "fe80::%4",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "10",
+  "operatingsystemrelease": "10",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.1.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 81 a5 92 87 74 16-44 f1 22 ae f4 e7 d3 e1",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 5,
-    "seconds": 19484,
-    "uptime": "5:24 hours"
+    "hours": 6,
+    "seconds": 22797,
+    "uptime": "6:19 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "6:19 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 22797,
+  "virtual": "vmware"
 }

--- a/facts/3.8/windows-2008 r2-x86_64.facts
+++ b/facts/3.8/windows-2008 r2-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.1.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 69 c3 5a be ab 4b-7d 91 a3 ab 74 e5 14 4a"
+      "serial_number": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.8.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "RJ2WFCMG7UF17CW\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "YECLHXSJQCSGCHG\\Administrator"
+    "user": "RJ2WFCMG7UF17CW\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.127.75",
+  "ipaddress6": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress6_Local Area Connection": "fe80::80be:a6bc:1766:4c99%11",
+  "ipaddress_Local Area Connection": "10.32.127.75",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:06:09",
+  "macaddress_Local Area Connection": "00:50:56:A2:06:09",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.00 GiB",
-      "available_bytes": 3219460096,
-      "capacity": "25.03%",
+      "available": "3.02 GiB",
+      "available_bytes": 3244814336,
+      "capacity": "24.43%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.00 GiB",
-      "used_bytes": 1074606080
+      "used": "1000.64 MiB",
+      "used_bytes": 1049251840
     }
   },
+  "memoryfree": "3.02 GiB",
+  "memoryfree_mb": 3094.49609375,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,22 +71,22 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.112.175",
+            "address": "10.32.127.75",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::7437:62b5:f700:aaf8%11",
+            "address": "fe80::80be:a6bc:1766:4c99%11",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.112.175",
-        "ip6": "fe80::7437:62b5:f700:aaf8%11",
-        "mac": "00:50:56:A2:A8:DE",
+        "ip": "10.32.127.75",
+        "ip6": "fe80::80be:a6bc:1766:4c99%11",
+        "mac": "00:50:56:A2:06:09",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.112.175",
-    "ip6": "fe80::7437:62b5:f700:aaf8%11",
-    "mac": "00:50:56:A2:A8:DE",
+    "ip": "10.32.127.75",
+    "ip6": "fe80::80be:a6bc:1766:4c99%11",
+    "mac": "00:50:56:A2:06:09",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008 R2",
+  "operatingsystemrelease": "2008 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.1.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 a8 96 79 37 b0 48-58 ef 71 fa 93 20 af 98",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 2,
-    "seconds": 8463,
-    "uptime": "2:21 hours"
+    "hours": 16,
+    "seconds": 60076,
+    "uptime": "16:41 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "16:41 hours",
+  "uptime_days": 0,
+  "uptime_hours": 16,
+  "uptime_seconds": 60076,
+  "virtual": "vmware"
 }

--- a/facts/3.8/windows-2008-x86_64.facts
+++ b/facts/3.8/windows-2008-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.1.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "Phoenix Technologies LTD",
     "product": {
       "name": "VMware Virtual Platform",
-      "serial_number": "VMware-42 22 17 5a 45 ec 14 6d-15 9a 96 fa 2d 85 56 f8"
+      "serial_number": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.8.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "QFMZ60DYQGU893J\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "LMUWWZE9FSD7LFT\\Administrator"
+    "user": "QFMZ60DYQGU893J\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.95",
+  "ipaddress6": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress6_Local Area Connection": "fe80::dd24:f5a9:347b:c256%10",
+  "ipaddress_Local Area Connection": "10.32.126.95",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.0",
   "kernelrelease": "6.0.6002",
   "kernelversion": "6.0.6002",
+  "macaddress": "00:50:56:A2:E0:07",
+  "macaddress_Local Area Connection": "00:50:56:A2:E0:07",
+  "manufacturer": "Phoenix Technologies LTD",
   "memory": {
     "system": {
       "available": "3.13 GiB",
-      "available_bytes": 3360677888,
-      "capacity": "21.72%",
+      "available_bytes": 3365146624,
+      "capacity": "21.62%",
       "total": "4.00 GiB",
       "total_bytes": 4293357568,
-      "used": "889.47 MiB",
-      "used_bytes": 932679680
+      "used": "885.21 MiB",
+      "used_bytes": 928210944
     }
   },
+  "memoryfree": "3.13 GiB",
+  "memoryfree_mb": 3209.25390625,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4094.46484375,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%10",
+  "network6_Local Area Connection": "fe80::%10",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,22 +71,22 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.118.156",
+            "address": "10.32.126.95",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::607e:1e1e:daef:d916%10",
+            "address": "fe80::dd24:f5a9:347b:c256%10",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%10"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.118.156",
-        "ip6": "fe80::607e:1e1e:daef:d916%10",
-        "mac": "00:50:56:A2:A1:3A",
+        "ip": "10.32.126.95",
+        "ip6": "fe80::dd24:f5a9:347b:c256%10",
+        "mac": "00:50:56:A2:E0:07",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%10"
       }
     },
-    "ip": "10.32.118.156",
-    "ip6": "fe80::607e:1e1e:daef:d916%10",
-    "mac": "00:50:56:A2:A1:3A",
+    "ip": "10.32.126.95",
+    "ip6": "fe80::dd24:f5a9:347b:c256%10",
+    "mac": "00:50:56:A2:E0:07",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%10",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2008",
+  "operatingsystemrelease": "2008",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\Administrator\\AppData\\Roaming\\Boxstarter",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware Virtual Platform",
   "puppetversion": "5.1.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 84 d9 ec 92 13 e1-da c1 23 6b ad bf 63 24",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 14,
-    "seconds": 53322,
-    "uptime": "14:48 hours"
+    "hours": 13,
+    "seconds": 49933,
+    "uptime": "13:52 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "13:52 hours",
+  "uptime_days": 0,
+  "uptime_hours": 13,
+  "uptime_seconds": 49933,
+  "virtual": "vmware"
 }

--- a/facts/3.8/windows-2012 r2-core-x86_64.facts
+++ b/facts/3.8/windows-2012 r2-core-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.1.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 9c 19 d0 99 8b cf-fb 50 a5 16 b7 83 a9 b4"
+      "serial_number": "VMware-42 22 87 dc e9 8e b0 64-92 77 c8 b4 50 65 ab 3d"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.8.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "YG5M1DAF3CFO3NM\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "R228JWRAQAHEWCE\\Administrator"
+    "user": "YG5M1DAF3CFO3NM\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.117.203",
+  "ipaddress6": "fe80::8529:e549:20d6:941a%12",
+  "ipaddress6_Ethernet0": "fe80::8529:e549:20d6:941a%12",
+  "ipaddress_Ethernet0": "10.32.117.203",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:04:07",
+  "macaddress_Ethernet0": "00:50:56:A2:04:07",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "5.35 GiB",
-      "available_bytes": 5743759360,
-      "capacity": "10.83%",
+      "available": "5.37 GiB",
+      "available_bytes": 5771239424,
+      "capacity": "10.41%",
       "total": "6.00 GiB",
       "total_bytes": 6441549824,
-      "used": "665.46 MiB",
-      "used_bytes": 697790464
+      "used": "639.26 MiB",
+      "used_bytes": 670310400
     }
   },
+  "memoryfree": "5.37 GiB",
+  "memoryfree_mb": 5503.8828125,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.117.150",
+            "address": "10.32.117.203",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::fc37:34df:11ca:629e%12",
+            "address": "fe80::8529:e549:20d6:941a%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.117.150",
-        "ip6": "fe80::fc37:34df:11ca:629e%12",
-        "mac": "00:50:56:A2:E2:6A",
+        "ip": "10.32.117.203",
+        "ip6": "fe80::8529:e549:20d6:941a%12",
+        "mac": "00:50:56:A2:04:07",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.117.150",
-    "ip6": "fe80::fc37:34df:11ca:629e%12",
-    "mac": "00:50:56:A2:E2:6A",
+    "ip": "10.32.117.203",
+    "ip6": "fe80::8529:e549:20d6:941a%12",
+    "mac": "00:50:56:A2:04:07",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.1.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 87 dc e9 8e b0 64-92 77 c8 b4 50 65 ab 3d",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
-    "days": 0,
-    "hours": 14,
-    "seconds": 52737,
-    "uptime": "14:38 hours"
+    "days": 1,
+    "hours": 24,
+    "seconds": 86465,
+    "uptime": "1 day"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "1 day",
+  "uptime_days": 1,
+  "uptime_hours": 24,
+  "uptime_seconds": 86465,
+  "virtual": "vmware"
 }

--- a/facts/3.8/windows-2012 r2-x86_64.facts
+++ b/facts/3.8/windows-2012 r2-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.1.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 98 da 22 23 49 26-f2 a6 ba 10 a6 3f 10 1f"
+      "serial_number": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.8.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GTT427VBINBGPOL\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "S4KMCYLUVBCHK53\\Administrator"
+    "user": "GTT427VBINBGPOL\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.127.212",
+  "ipaddress6": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress6_Ethernet0": "fe80::a0b5:f374:6703:1ec6%12",
+  "ipaddress_Ethernet0": "10.32.127.212",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:D9:94",
+  "macaddress_Ethernet0": "00:50:56:A2:D9:94",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "5.21 GiB",
-      "available_bytes": 5594898432,
-      "capacity": "13.14%",
+      "available": "5.23 GiB",
+      "available_bytes": 5617561600,
+      "capacity": "12.79%",
       "total": "6.00 GiB",
       "total_bytes": 6441549824,
-      "used": "807.43 MiB",
-      "used_bytes": 846651392
+      "used": "785.82 MiB",
+      "used_bytes": 823988224
     }
   },
+  "memoryfree": "5.23 GiB",
+  "memoryfree_mb": 5357.32421875,
+  "memorysize": "6.00 GiB",
+  "memorysize_mb": 6143.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.118.94",
+            "address": "10.32.127.212",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::7850:3be7:1564:f89e%12",
+            "address": "fe80::a0b5:f374:6703:1ec6%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.118.94",
-        "ip6": "fe80::7850:3be7:1564:f89e%12",
-        "mac": "00:50:56:A2:34:62",
+        "ip": "10.32.127.212",
+        "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+        "mac": "00:50:56:A2:D9:94",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.118.94",
-    "ip6": "fe80::7850:3be7:1564:f89e%12",
-    "mac": "00:50:56:A2:34:62",
+    "ip": "10.32.127.212",
+    "ip6": "fe80::a0b5:f374:6703:1ec6%12",
+    "mac": "00:50:56:A2:D9:94",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012 R2",
+  "operatingsystemrelease": "2012 R2",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
-  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "osfamily": "windows",
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.1.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 25 a0 25 6f e9 9f-9b b9 ac b4 f6 e7 87 83",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 4,
-    "seconds": 16626,
-    "uptime": "4:37 hours"
+    "hours": 0,
+    "seconds": 1449,
+    "uptime": "0:24 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "0:24 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 1449,
+  "virtual": "vmware"
 }

--- a/facts/3.8/windows-2012-x86_64.facts
+++ b/facts/3.8/windows-2012-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.1.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 c3 3a d9 19 54 e9-a5 c2 0a 58 c0 67 67 8a"
+      "serial_number": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.8.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "WX8QEA42SDYVTT6\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "XG9U5I9UFGFKVDY\\Administrator"
+    "user": "WX8QEA42SDYVTT6\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.112.136",
+  "ipaddress6": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress6_Ethernet0": "fe80::256a:cde6:f021:6c49%12",
+  "ipaddress_Ethernet0": "10.32.112.136",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.2",
   "kernelrelease": "6.2.9200",
   "kernelversion": "6.2.9200",
+  "macaddress": "00:50:56:A2:5B:88",
+  "macaddress_Ethernet0": "00:50:56:A2:5B:88",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "3.21 GiB",
-      "available_bytes": 3445665792,
-      "capacity": "19.76%",
+      "available": "3.28 GiB",
+      "available_bytes": 3524845568,
+      "capacity": "17.91%",
       "total": "4.00 GiB",
       "total_bytes": 4294062080,
-      "used": "809.09 MiB",
-      "used_bytes": 848396288
+      "used": "733.58 MiB",
+      "used_bytes": 769216512
     }
   },
+  "memoryfree": "3.28 GiB",
+  "memoryfree_mb": 3361.5546875,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.13671875,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%12",
+  "network6_Ethernet0": "fe80::%12",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.127.73",
+            "address": "10.32.112.136",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::3146:5227:27d:5a9e%12",
+            "address": "fe80::256a:cde6:f021:6c49%12",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%12"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.127.73",
-        "ip6": "fe80::3146:5227:27d:5a9e%12",
-        "mac": "00:50:56:A2:E6:9D",
+        "ip": "10.32.112.136",
+        "ip6": "fe80::256a:cde6:f021:6c49%12",
+        "mac": "00:50:56:A2:5B:88",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%12"
       }
     },
-    "ip": "10.32.127.73",
-    "ip6": "fe80::3146:5227:27d:5a9e%12",
-    "mac": "00:50:56:A2:E6:9D",
+    "ip": "10.32.112.136",
+    "ip6": "fe80::256a:cde6:f021:6c49%12",
+    "mac": "00:50:56:A2:5B:88",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%12",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2012",
+  "operatingsystemrelease": "2012",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.1.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 6c 2c 94 f0 1e 61-5b 6c d8 90 b5 86 99 a5",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 2,
-    "seconds": 8394,
-    "uptime": "2:19 hours"
+    "hours": 15,
+    "seconds": 54464,
+    "uptime": "15:07 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "15:07 hours",
+  "uptime_days": 0,
+  "uptime_hours": 15,
+  "uptime_seconds": 54464,
+  "virtual": "vmware"
 }

--- a/facts/3.8/windows-2016-x86_64.facts
+++ b/facts/3.8/windows-2016-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.1.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 42 9a 56 e4 63 9a-94 88 1d 17 4f ca 73 30"
+      "serial_number": "VMware-42 22 28 b9 e9 7f 7e ac-48 14 76 dc f2 42 91 47"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.8.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "GR3WVWP2B63LSOM\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "AMSCD5AZ3LH02KC\\Administrator"
+    "user": "GR3WVWP2B63LSOM\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.60",
+  "ipaddress6": "fe80::48:3cd:d72:aa17%5",
+  "ipaddress6_Ethernet0": "fe80::48:3cd:d72:aa17%5",
+  "ipaddress_Ethernet0": "10.32.125.60",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "10.0",
   "kernelrelease": "10.0.14393",
   "kernelversion": "10.0.14393",
+  "macaddress": "00:50:56:A2:38:BE",
+  "macaddress_Ethernet0": "00:50:56:A2:38:BE",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.89 GiB",
-      "available_bytes": 3104514048,
-      "capacity": "27.70%",
+      "available": "2.92 GiB",
+      "available_bytes": 3132919808,
+      "capacity": "27.04%",
       "total": "4.00 GiB",
       "total_bytes": 4294057984,
-      "used": "1.11 GiB",
-      "used_bytes": 1189543936
+      "used": "1.08 GiB",
+      "used_bytes": 1161138176
     }
   },
+  "memoryfree": "2.92 GiB",
+  "memoryfree_mb": 2987.78515625,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.1328125,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%5",
+  "network6_Ethernet0": "fe80::%5",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.114.1",
+            "address": "10.32.125.60",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::190b:7cc7:64bb:93c1%5",
+            "address": "fe80::48:3cd:d72:aa17%5",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%5"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.114.1",
-        "ip6": "fe80::190b:7cc7:64bb:93c1%5",
-        "mac": "00:50:56:A2:83:A8",
+        "ip": "10.32.125.60",
+        "ip6": "fe80::48:3cd:d72:aa17%5",
+        "mac": "00:50:56:A2:38:BE",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%5"
       }
     },
-    "ip": "10.32.114.1",
-    "ip6": "fe80::190b:7cc7:64bb:93c1%5",
-    "mac": "00:50:56:A2:83:A8",
+    "ip": "10.32.125.60",
+    "ip6": "fe80::48:3cd:d72:aa17%5",
+    "mac": "00:50:56:A2:38:BE",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%5",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "2016",
+  "operatingsystemrelease": "2016",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,31 +120,43 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals;C:\\Users\\cyg_server\\AppData\\Local\\Microsoft\\WindowsApps",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
     "models": [
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz",
-      "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+      "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz"
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.1.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 28 b9 e9 7f 7e ac-48 14 76 dc f2 42 91 47",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 1,
-    "seconds": 6183,
-    "uptime": "1:43 hours"
+    "hours": 8,
+    "seconds": 29497,
+    "uptime": "8:11 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "8:11 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29497,
+  "virtual": "vmware"
 }

--- a/facts/3.8/windows-7-x86_64.facts
+++ b/facts/3.8/windows-7-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.1.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Local Area Connection": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 83 07 af 1d a3 e4-37 54 51 15 43 45 45 31"
+      "serial_number": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.8.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "N6IFGFZXW976ITI\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "B3LKSVKR104RSYY\\Administrator"
+    "user": "N6IFGFZXW976ITI\\Administrator"
   },
+  "interfaces": "Local Area Connection",
+  "ipaddress": "10.32.126.90",
+  "ipaddress6": "fe80::2121:2899:8986:e379%11",
+  "ipaddress6_Local Area Connection": "fe80::2121:2899:8986:e379%11",
+  "ipaddress_Local Area Connection": "10.32.126.90",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.1",
   "kernelrelease": "6.1.7601",
   "kernelversion": "6.1.7601",
+  "macaddress": "00:50:56:A2:78:83",
+  "macaddress_Local Area Connection": "00:50:56:A2:78:83",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
       "available": "2.96 GiB",
-      "available_bytes": 3173531648,
-      "capacity": "26.09%",
+      "available_bytes": 3181334528,
+      "capacity": "25.91%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
       "used": "1.04 GiB",
-      "used_bytes": 1120534528
+      "used_bytes": 1112731648
     }
   },
+  "memoryfree": "2.96 GiB",
+  "memoryfree_mb": 3033.95703125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Local Area Connection": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Local Area Connection": "ffff:ffff:ffff:ffff::",
+  "netmask_Local Area Connection": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%11",
+  "network6_Local Area Connection": "fe80::%11",
+  "network_Local Area Connection": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,22 +71,22 @@
       "Local Area Connection": {
         "bindings": [
           {
-            "address": "10.32.116.94",
+            "address": "10.32.126.90",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::7077:7fd8:ab4:e16c%11",
+            "address": "fe80::2121:2899:8986:e379%11",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%11"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.116.94",
-        "ip6": "fe80::7077:7fd8:ab4:e16c%11",
-        "mac": "00:50:56:A2:87:1D",
+        "ip": "10.32.126.90",
+        "ip6": "fe80::2121:2899:8986:e379%11",
+        "mac": "00:50:56:A2:78:83",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%11"
       }
     },
-    "ip": "10.32.116.94",
-    "ip6": "fe80::7077:7fd8:ab4:e16c%11",
-    "mac": "00:50:56:A2:87:1D",
+    "ip": "10.32.126.90",
+    "ip6": "fe80::2121:2899:8986:e379%11",
+    "mac": "00:50:56:A2:78:83",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%11",
     "primary": "Local Area Connection"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "7",
+  "operatingsystemrelease": "7",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.1.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 54 f8 03 5a 02 c9-79 8e 1a a7 0a fb 58 5a",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 6,
-    "seconds": 25052,
-    "uptime": "6:57 hours"
+    "hours": 8,
+    "seconds": 29090,
+    "uptime": "8:04 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "8:04 hours",
+  "uptime_days": 0,
+  "uptime_hours": 8,
+  "uptime_seconds": 29090,
+  "virtual": "vmware"
 }

--- a/facts/3.8/windows-8.1-x86_64.facts
+++ b/facts/3.8/windows-8.1-x86_64.facts
@@ -1,35 +1,67 @@
 {
   "agent_specified_environment": "production",
   "aio_agent_version": "5.1.0",
+  "architecture": "x64",
+  "dhcp_servers": {
+    "Ethernet0": "10.32.22.10",
+    "system": "10.32.22.10"
+  },
   "dmi": {
     "manufacturer": "VMware, Inc.",
     "product": {
       "name": "VMware7,1",
-      "serial_number": "VMware-42 22 3a ab e9 b0 27 a7-cb 3e d1 e5 a1 b6 c5 eb"
+      "serial_number": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b"
     }
   },
+  "domain": "example.com",
   "env_windows_installdir": "C:\\Program Files\\Puppet Labs\\Puppet",
   "facterversion": "3.8.0",
+  "fqdn": "foo.example.com",
+  "hardwareisa": "x64",
+  "hardwaremodel": "x86_64",
+  "hostname": "foo",
+  "id": "B5GMZC25YP3WRFT\\Administrator",
   "identity": {
     "privileged": true,
-    "user": "N7W8EHGNWP2X23C\\Administrator"
+    "user": "B5GMZC25YP3WRFT\\Administrator"
   },
+  "interfaces": "Ethernet0",
+  "ipaddress": "10.32.125.84",
+  "ipaddress6": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress6_Ethernet0": "fe80::e490:85dc:9a71:4d9e%3",
+  "ipaddress_Ethernet0": "10.32.125.84",
   "is_virtual": true,
   "kernel": "windows",
   "kernelmajversion": "6.3",
   "kernelrelease": "6.3.9600",
   "kernelversion": "6.3.9600",
+  "macaddress": "00:50:56:A2:FD:34",
+  "macaddress_Ethernet0": "00:50:56:A2:FD:34",
+  "manufacturer": "VMware, Inc.",
   "memory": {
     "system": {
-      "available": "2.81 GiB",
-      "available_bytes": 3020300288,
-      "capacity": "29.66%",
+      "available": "2.40 GiB",
+      "available_bytes": 2581467136,
+      "capacity": "39.88%",
       "total": "4.00 GiB",
       "total_bytes": 4294066176,
-      "used": "1.19 GiB",
-      "used_bytes": 1273765888
+      "used": "1.59 GiB",
+      "used_bytes": 1712599040
     }
   },
+  "memoryfree": "2.40 GiB",
+  "memoryfree_mb": 2461.87890625,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4095.140625,
+  "mtu_Ethernet0": 1500,
+  "netmask": "255.255.240.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_Ethernet0": "ffff:ffff:ffff:ffff::",
+  "netmask_Ethernet0": "255.255.240.0",
+  "network": "10.32.112.0",
+  "network6": "fe80::%3",
+  "network6_Ethernet0": "fe80::%3",
+  "network_Ethernet0": "10.32.112.0",
   "networking": {
     "dhcp": "10.32.22.10",
     "domain": "example.com",
@@ -39,22 +71,22 @@
       "Ethernet0": {
         "bindings": [
           {
-            "address": "10.32.127.146",
+            "address": "10.32.125.84",
             "netmask": "255.255.240.0",
             "network": "10.32.112.0"
           }
         ],
         "bindings6": [
           {
-            "address": "fe80::bcf9:9d26:aeb4:23f2%3",
+            "address": "fe80::e490:85dc:9a71:4d9e%3",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::%3"
           }
         ],
         "dhcp": "10.32.22.10",
-        "ip": "10.32.127.146",
-        "ip6": "fe80::bcf9:9d26:aeb4:23f2%3",
-        "mac": "00:50:56:A2:81:A8",
+        "ip": "10.32.125.84",
+        "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+        "mac": "00:50:56:A2:FD:34",
         "mtu": 1500,
         "netmask": "255.255.240.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -62,9 +94,9 @@
         "network6": "fe80::%3"
       }
     },
-    "ip": "10.32.127.146",
-    "ip6": "fe80::bcf9:9d26:aeb4:23f2%3",
-    "mac": "00:50:56:A2:81:A8",
+    "ip": "10.32.125.84",
+    "ip6": "fe80::e490:85dc:9a71:4d9e%3",
+    "mac": "00:50:56:A2:FD:34",
     "mtu": 1500,
     "netmask": "255.255.240.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -72,6 +104,9 @@
     "network6": "fe80::%3",
     "primary": "Ethernet0"
   },
+  "operatingsystem": "windows",
+  "operatingsystemmajrelease": "8.1",
+  "operatingsystemrelease": "8.1",
   "os": {
     "architecture": "x64",
     "family": "windows",
@@ -85,7 +120,12 @@
       "system32": "C:\\Windows\\system32"
     }
   },
+  "osfamily": "windows",
   "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\facter\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\hiera\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\mcollective\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\sys\\tools\\bin;C:\\cygwin64\\bin;C:\\ProgramData\\Boxstarter;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Program Files\\Git\\cmd;C:\\Packer\\SysInternals",
+  "physicalprocessorcount": 2,
+  "processor0": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processor1": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "x64",
@@ -95,21 +135,28 @@
     ],
     "physicalcount": 2
   },
+  "productname": "VMware7,1",
   "puppetversion": "5.1.0",
   "ruby": {
     "platform": "x64-mingw32",
     "sitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.1"
   },
+  "rubyplatform": "x64-mingw32",
+  "rubysitedir": "C:/Program Files/Puppet Labs/Puppet/sys/ruby/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.1",
+  "serialnumber": "VMware-42 22 4d be a7 64 37 f6-69 53 5c ec 5e 46 f2 0b",
+  "system32": "C:\\Windows\\system32",
   "system_uptime": {
     "days": 0,
-    "hours": 15,
-    "seconds": 54546,
-    "uptime": "15:09 hours"
+    "hours": 18,
+    "seconds": 66322,
+    "uptime": "18:25 hours"
   },
   "timezone": "Coordinated Universal Time",
-  "virtual": "vmware",
-  "domain": "example.com",
-  "hostname": "foo",
-  "fqdn": "foo.example.com"
+  "uptime": "18:25 hours",
+  "uptime_days": 0,
+  "uptime_hours": 18,
+  "uptime_seconds": 66322,
+  "virtual": "vmware"
 }


### PR DESCRIPTION
The Windows facts that I generated in #46 didn't include the legacy facts for the 3.x series (`--show-legacy`) so I've regenerated them.

/cc @josephoaks @DavidS 