### PR TITLE
AIX 7.1 legacy facts

### DIFF
--- a/facts/3.9/aix-7.1-power.facts
+++ b/facts/3.9/aix-7.1-power.facts
@@ -1,16 +1,27 @@
 {
   "aio_agent_version": "5.3.4",
+  "architecture": "PowerPC_POWER8",
   "augeas": {
     "version": "1.8.1"
   },
+  "augeasversion": "1.8.1",
+  "blockdevice_hdisk0_size": 64424509440,
+  "blockdevices": "hdisk0",
   "disks": {
     "hdisk0": {
       "size": "60.00 GiB",
       "size_bytes": 64424509440
     }
   },
+  "domain": "example.com",
   "facterversion": "3.9.4",
   "filesystems": "ahafs,autofs,cachefs,cdrfs,cifs,jfs,jfs2,namefs,nfs,nfs3,nfs4,pmemfs,procfs,sfs,stnfs,udfs",
+  "fqdn": "hostname.example.com",
+  "gid": "system",
+  "hardwareisa": "powerpc",
+  "hardwaremodel": "IBM,8284-22A",
+  "hostname": "hostname",
+  "id": "root",
   "identity": {
     "gid": 0,
     "group": "system",
@@ -18,35 +29,49 @@
     "uid": 0,
     "user": "root"
   },
+  "interfaces": "lo0,en0,en1,sit0",
+  "ipaddress": "10.10.136.15",
+  "ipaddress6_en0": "fd8c:215d:178e:12:fe1:6fff:fe0d:4302",
+  "ipaddress6_lo0": "::1",
+  "ipaddress_en1": "10.10.136.15",
+  "ipaddress_lo0": "127.0.0.1",
   "kernel": "AIX",
   "kernelmajversion": "7100",
   "kernelrelease": "7100-04-04-1717",
   "kernelversion": "7100",
+  "macaddress": "fa:79:8c:90:11:21",
+  "macaddress_en0": "fa:79:8c:90:11:20",
+  "macaddress_en1": "fa:79:8c:90:11:21",
+  "macaddress_sit0": "0a:0a:88:0f:00:00",
   "memory": {
     "swap": {
       "available": "1.99 GiB",
-      "available_bytes": 2132410368,
-      "capacity": "0.70%",
+      "available_bytes": 2132148224,
+      "capacity": "0.71%",
       "total": "2.00 GiB",
       "total_bytes": 2147483648,
-      "used": "14.38 MiB",
-      "used_bytes": 15073280
+      "used": "14.63 MiB",
+      "used_bytes": 15335424
     },
     "system": {
-      "available": "271.10 MiB",
-      "available_bytes": 284270592,
-      "capacity": "93.38%",
+      "available": "170.20 MiB",
+      "available_bytes": 178462720,
+      "capacity": "95.84%",
       "total": "4.00 GiB",
       "total_bytes": 4294967296,
-      "used": "3.74 GiB",
-      "used_bytes": 4010696704
+      "used": "3.83 GiB",
+      "used_bytes": 4116504576
     }
   },
+  "memoryfree": "170.20 MiB",
+  "memoryfree_mb": 170.1953125,
+  "memorysize": "4.00 GiB",
+  "memorysize_mb": 4096.0,
   "mountpoints": {
     "/": {
       "available": "32.92 GiB",
-      "available_bytes": 35347619840,
-      "capacity": "5.94%",
+      "available_bytes": 35343736832,
+      "capacity": "5.95%",
       "device": "/dev/hd4",
       "filesystem": "jfs2",
       "options": [
@@ -56,7 +81,7 @@
       "size": "35.00 GiB",
       "size_bytes": 37580963840,
       "used": "2.08 GiB",
-      "used_bytes": 2233344000
+      "used_bytes": 2237227008
     },
     "/admin": {
       "available": "511.57 MiB",
@@ -89,8 +114,8 @@
     },
     "/tmp": {
       "available": "7.61 GiB",
-      "available_bytes": 8172941312,
-      "capacity": "4.85%",
+      "available_bytes": 8172847104,
+      "capacity": "4.86%",
       "device": "/dev/hd3",
       "filesystem": "jfs2",
       "options": [
@@ -99,8 +124,8 @@
       ],
       "size": "8.00 GiB",
       "size_bytes": 8589934592,
-      "used": "397.68 MiB",
-      "used_bytes": 416993280
+      "used": "397.77 MiB",
+      "used_bytes": 417087488
     },
     "/usr": {
       "available": "2.90 GiB",
@@ -119,8 +144,8 @@
     },
     "/var": {
       "available": "5.96 GiB",
-      "available_bytes": 6404235264,
-      "capacity": "0.59%",
+      "available_bytes": 6403338240,
+      "capacity": "0.61%",
       "device": "/dev/hd9var",
       "filesystem": "jfs2",
       "options": [
@@ -129,8 +154,8 @@
       ],
       "size": "6.00 GiB",
       "size_bytes": 6442450944,
-      "used": "36.45 MiB",
-      "used_bytes": 38215680
+      "used": "37.30 MiB",
+      "used_bytes": 39112704
     },
     "/var/adm/ras/livedump": {
       "available": "255.64 MiB",
@@ -148,6 +173,20 @@
       "used_bytes": 376832
     }
   },
+  "mtu_en0": 1500,
+  "mtu_en1": 1500,
+  "mtu_lo0": 16896,
+  "mtu_sit0": 1480,
+  "netmask": "255.255.255.0",
+  "netmask6_en0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_en1": "255.255.255.0",
+  "netmask_lo0": "255.0.0.0",
+  "network": "10.10.136.0",
+  "network6_en0": "fd8c:215d:178e:12::",
+  "network6_lo0": "::1",
+  "network_en1": "10.10.136.0",
+  "network_lo0": "127.0.0.0",
   "networking": {
     "domain": "example.com",
     "fqdn": "hostname.example.com",
@@ -221,6 +260,9 @@
     "network": "10.10.136.0",
     "primary": "en1"
   },
+  "operatingsystem": "AIX",
+  "operatingsystemmajrelease": "7100",
+  "operatingsystemrelease": "7100-04-04-1717",
   "os": {
     "architecture": "PowerPC_POWER8",
     "family": "AIX",
@@ -231,6 +273,7 @@
       "major": "7100"
     }
   },
+  "osfamily": "AIX",
   "partitions": {
     "/dev/hd11admin": {
       "filesystem": "jfs2",
@@ -297,6 +340,15 @@
     }
   },
   "path": "/usr/bin:/etc:/usr/sbin:/usr/ucb:/usr/bin/X11:/sbin:/opt/IBM/ibm-java-ppc64-70/jre/bin:/opt/IBM/ibm-java-ppc64-70/bin:/usr/local/bin:/opt/puppetlabs/bin",
+  "processor0": "PowerPC_POWER8",
+  "processor1": "PowerPC_POWER8",
+  "processor2": "PowerPC_POWER8",
+  "processor3": "PowerPC_POWER8",
+  "processor4": "PowerPC_POWER8",
+  "processor5": "PowerPC_POWER8",
+  "processor6": "PowerPC_POWER8",
+  "processor7": "PowerPC_POWER8",
+  "processorcount": 8,
   "processors": {
     "count": 8,
     "isa": "powerpc",
@@ -317,6 +369,10 @@
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.4.0",
     "version": "2.4.3"
   },
+  "rubyplatform": "powerpc-aix7.1.0.0",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.3",
+  "serialnumber": "2114E8W",
   "ssh": {
     "dsa": {
       "fingerprints": {
@@ -340,11 +396,25 @@
       "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDzIG+OpW/3tONe3+qyxCz84Axzg+WEVJ8LZshWqEKv8Quyc+Qe7xexiik7TfLper61+S5dt3Ah8zUA7ztBt60F44bU9Ijl+qc9zhWgrkOFjbX6XbsIlKC57j30Oas0C5wE4p59rBKGNXm8DDQuwcLGdZrL8MRFPoLwr0jLNVU9dhWHP9+hTY90mKhZCBZFustMBt1AB+HzmzQnTViiqTghAZwe26xTPPsGNo5ukcvpW25hBctUl98snPtyv3r6WobV/DNfMCfQQ3y9dHuIAZV8UQ5AHHvbVwDnJ4iZv326U1qbuuthhdLywUGG2AOsH2TAXM+em3TcOjqn4MtbuB9x"
     }
   },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBAM4KcYkkWgew69+XBlGnHbRmLmaueoM7DcgLKhDZuvFhTbK2xp5XB0cMomj6VAZjFjhmQucFH0yCi3veOdHR8LbOif4NHUKnL1SppHmfJJpQ87dlSJHNTirhEYZkb2lZbz0inkBxhrmuOL4LNfPre7QBvNu5xy5oyX/nDk/ZV8EpAAAAFQDsK0OLQXc2y8VaFxvQgIwNSXiELQAAAIB9oksOK9NyDJyDSSfdYDgNxrdc4ktuFKUqsbuZ1DWki5QUcMkXp/GkZoPZpJq0j+xyNci21HabcpWUeLkUtBTVvZ51hy5WJ79KdhLZA12xGSrZIDMSJAIzdtBTFbdY9weizOj/25Jka1JNHKAgqEqOR3vcps5wb/Q8ggo68zAdTwAAAIEAvt1XUNHtlqVb/yqesm75fAIIqBMW4I84ifrlJGB1Lsi2fh3BLNMC9L7LtTLUTnlH89lbGrQcksJ+G6FzkyaDaQYydBJFl3fvzECfQDTPyKCClUFOwjcmgXdwk8VxRue+FW2CVJsUOQrX2dIeWWWkan0q2HTnTZksQMC7byt1Uhc=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBG9lRf9GWAkU1bMwElHtbkolIdfp2MIRLotUw5j3FWIHYpfnFiQoF4RQbwVLznYjbAK3151aADu9Gue5xhrcpvw=",
+  "sshfp_dsa": "SSHFP 2 1 1bc9744bb019cc61c51806abd803c725f6574114\nSSHFP 2 2 3a51b61181ca4a70b76c2ff12672ae122ef17b9f29e2c1703515574a46308a15",
+  "sshfp_ecdsa": "SSHFP 3 1 7620b25dda681059bcc53ffcf4fcc52a05d48d2f\nSSHFP 3 2 18131411ca4966e190c9ed78767abf0ab535ada8e584daabced337dd23963b96",
+  "sshfp_rsa": "SSHFP 1 1 a258b0a48bdca66dd5a8e82db664035b949aeec4\nSSHFP 1 2 0912e0f2eb5d9cf3ca8f886a27a4f03dd8783af79fb6e31ce8d01552c77d1a28",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDzIG+OpW/3tONe3+qyxCz84Axzg+WEVJ8LZshWqEKv8Quyc+Qe7xexiik7TfLper61+S5dt3Ah8zUA7ztBt60F44bU9Ijl+qc9zhWgrkOFjbX6XbsIlKC57j30Oas0C5wE4p59rBKGNXm8DDQuwcLGdZrL8MRFPoLwr0jLNVU9dhWHP9+hTY90mKhZCBZFustMBt1AB+HzmzQnTViiqTghAZwe26xTPPsGNo5ukcvpW25hBctUl98snPtyv3r6WobV/DNfMCfQQ3y9dHuIAZV8UQ5AHHvbVwDnJ4iZv326U1qbuuthhdLywUGG2AOsH2TAXM+em3TcOjqn4MtbuB9x",
+  "swapfree": "1.99 GiB",
+  "swapfree_mb": 2033.375,
+  "swapsize": "2.00 GiB",
+  "swapsize_mb": 2048.0,
   "system_uptime": {
-    "days": 14,
-    "hours": 336,
-    "seconds": 1211220,
-    "uptime": "14 days"
+    "days": 19,
+    "hours": 472,
+    "seconds": 1701000,
+    "uptime": "19 days"
   },
-  "timezone": "UTC"
+  "timezone": "UTC",
+  "uptime": "19 days",
+  "uptime_days": 19,
+  "uptime_hours": 472,
+  "uptime_seconds": 1701000
 }


### PR DESCRIPTION
Apparently rspec-puppet-facts uses legacy facts, adding legacy facts.