### PR TITLE
Explicitly use bash not sh

### DIFF
--- a/facts/Vagrantfile
+++ b/facts/Vagrantfile
@@ -228,20 +228,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
   config.vm.define "freebsd-12-x86_64" do |host|
     host.vm.box = "bento/freebsd-12.0"
-    host.ssh.shell = '/bin/sh'
-    host.vm.network :private_network, ip: '10.0.0.2'
-    host.vm.synced_folder ".", "/vagrant", :nfs => true
-    host.vm.provision "shell", inline: "pkg install -y devel/ruby-gems"
+    host.vm.synced_folder ".", "/vagrant"
+    host.vm.provision "shell", inline: "pkg install -y bash devel/ruby-gems"
+    host.vm.provision "shell", inline: "ln -sf /usr/local/bin/bash /bin/bash"
     host.vm.provision "file", source: "Gemfile", destination: "Gemfile"
     host.vm.provision "shell", path: "get_facts.sh"
     host.vm.provision "shell", inline: "/sbin/shutdown -p now"
   end
   config.vm.define "freebsd-11-x86_64" do |host|
     host.vm.box = "bento/freebsd-11.2"
-    host.ssh.shell = '/bin/sh'
-    host.vm.network :private_network, ip: '10.0.0.2'
-    host.vm.synced_folder ".", "/vagrant", :nfs => true
-    host.vm.provision "shell", inline: "pkg install -y devel/ruby-gems"
+    host.vm.synced_folder ".", "/vagrant"
+    host.vm.provision "shell", inline: "pkg install -y bash devel/ruby-gems"
+    host.vm.provision "shell", inline: "ln -sf /usr/local/bin/bash /bin/bash"
     host.vm.provision "file", source: "Gemfile", destination: "Gemfile"
     host.vm.provision "shell", path: "get_facts.sh"
     host.vm.provision "shell", inline: "/sbin/shutdown -p now"

--- a/facts/get_facts.sh
+++ b/facts/get_facts.sh
@@ -122,6 +122,11 @@ case "${osfamily}" in
 'FreeBSD')
   pkg update
   pkg install -y sysutils/puppet5 sysutils/facter sysutils/rubygem-bundler
+  # something about the pkg update process causes the shared folder mount to
+  # get into an unusable state, so we remount it here before generating any
+  # fact sets.
+  umount /vagrant
+  mount -t vboxvfs Vagrant /vagrant
   output_file="/vagrant/$(facter --version | cut -d. -f1,2)/$(facter operatingsystem | tr '[:upper:]' '[:lower:]')-$(facter operatingsystemmajrelease)-$(facter hardwaremodel).facts"
   mkdir -p $(dirname ${output_file})
   [ ! -f ${output_file} ] && facter --show-legacy -p -j | tee ${output_file}

--- a/facts/get_facts.sh
+++ b/facts/get_facts.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export PATH=/opt/puppetlabs/bin:$PATH
 


### PR DESCRIPTION
Commit 369c1ec40fa3761f3229f01431edec416645907d changed the shebang in `get_facts.sh` from `/bin/bash` to `/bin/sh`. The problem is the script contains some bash-isms and `/bin/sh` on some OS's is not bash, notably OpenBSD where it's Korn shell. I originally handled this by installing the bash package and symlinking it as `/bin/bash` so the script worked, however since the referenced commit the script runs but errors as it's using `/bin/ksh` under the hood.

https://github.com/camptocamp/facterdb/blob/master/facts/get_facts.sh#L52-L57 seems to be the bit that causes problems, particularly the `=~` operator which I can't see is supported on the OpenBSD version of `/bin/ksh`.

This commit reverts the shebang change, and I'm pinging @xaque208 as the author of the commit to see if there's a better way to get it working on FreeBSD, (I confess to not knowing what `/bin/sh` really is on FreeBSD).