### PR TITLE
regenerate Archlinux / VZ 7 facts

### DIFF
--- a/facts/3.10/archlinux-x86_64.facts
+++ b/facts/3.10/archlinux-x86_64.facts
@@ -1,6 +1,23 @@
 {
+  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
+  },
+  "augeasversion": "1.12.0",
+  "bios_release_date": "12/01/2006",
+  "bios_vendor": "innotek GmbH",
+  "bios_version": "VirtualBox",
+  "blockdevice_sda_model": "VBOX HARDDISK",
+  "blockdevice_sda_size": 21474836480,
+  "blockdevice_sda_vendor": "ATA",
+  "blockdevices": "sda",
+  "boardmanufacturer": "Oracle Corporation",
+  "boardproductname": "VirtualBox",
+  "boardserialnumber": "0",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "eth0": "10.0.2.2",
+    "system": "10.0.2.2"
   },
   "disks": {
     "sda": {
@@ -28,15 +45,21 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "5785c0d5-3d4d-4f95-83ea-93e0ad75833c"
+      "uuid": "eb6e0002-bde8-4896-b25f-780ea4ce4e2d"
     }
   },
   "facterversion": "3.10.0",
   "filesystems": "btrfs",
   "fips_enabled": false,
+  "fqdn": "archlinux",
+  "gid": "root",
+  "hardwareisa": "unknown",
+  "hardwaremodel": "x86_64",
+  "hostname": "archlinux",
   "hypervisors": {
     "virtualbox": {}
   },
+  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -44,41 +67,55 @@
     "uid": 0,
     "user": "root"
   },
+  "interfaces": "eth0,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::a00:27ff:feaf:6265",
+  "ipaddress6_eth0": "fe80::a00:27ff:feaf:6265",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
   "kernel": "Linux",
-  "kernelmajversion": "5.2",
-  "kernelrelease": "5.2.13-arch1-1-ARCH",
-  "kernelversion": "5.2.13",
+  "kernelmajversion": "5.3",
+  "kernelrelease": "5.3.1-arch1-1-ARCH",
+  "kernelversion": "5.3.1",
   "load_averages": {
-    "15m": 0.03,
-    "1m": 0.08,
-    "5m": 0.08
+    "15m": 0.25,
+    "1m": 1.07,
+    "5m": 0.57
   },
+  "macaddress": "08:00:27:af:62:65",
+  "macaddress_eth0": "08:00:27:af:62:65",
+  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "1.92 GiB",
-      "available_bytes": 2062544896,
-      "capacity": "0%",
+      "available": "1.91 GiB",
+      "available_bytes": 2055716864,
+      "capacity": "0.13%",
       "total": "1.92 GiB",
-      "total_bytes": 2062544896,
-      "used": "0 bytes",
-      "used_bytes": 0
+      "total_bytes": 2058350592,
+      "used": "2.51 MiB",
+      "used_bytes": 2633728
     },
     "system": {
-      "available": "822.27 MiB",
-      "available_bytes": 862208000,
-      "capacity": "16.49%",
-      "total": "984.58 MiB",
-      "total_bytes": 1032404992,
-      "used": "162.31 MiB",
-      "used_bytes": 170196992
+      "available": "797.25 MiB",
+      "available_bytes": 835977216,
+      "capacity": "18.90%",
+      "total": "983.05 MiB",
+      "total_bytes": 1030807552,
+      "used": "185.80 MiB",
+      "used_bytes": 194830336
     }
   },
+  "memoryfree": "797.25 MiB",
+  "memoryfree_mb": 797.25,
+  "memorysize": "983.05 MiB",
+  "memorysize_mb": 983.0546875,
   "mountpoints": {
     "/": {
-      "available": "16.60 GiB",
-      "available_bytes": 17825533952,
-      "capacity": "8.17%",
+      "available": "16.02 GiB",
+      "available_bytes": 17204256768,
+      "capacity": "11.39%",
       "device": "/dev/sda2",
       "filesystem": "btrfs",
       "options": [
@@ -89,13 +126,13 @@
         "subvol=/"
       ],
       "size": "18.08 GiB",
-      "size_bytes": 19411238912,
-      "used": "1.48 GiB",
-      "used_bytes": 1585704960
+      "size_bytes": 19415433216,
+      "used": "2.06 GiB",
+      "used_bytes": 2211176448
     },
     "/dev": {
-      "available": "485.05 MiB",
-      "available_bytes": 508616704,
+      "available": "484.30 MiB",
+      "available_bytes": 507826176,
       "capacity": "0%",
       "device": "dev",
       "filesystem": "devtmpfs",
@@ -103,12 +140,12 @@
         "rw",
         "nosuid",
         "relatime",
-        "size=496696k",
-        "nr_inodes=124174",
+        "size=495924k",
+        "nr_inodes=123981",
         "mode=755"
       ],
-      "size": "485.05 MiB",
-      "size_bytes": 508616704,
+      "size": "484.30 MiB",
+      "size_bytes": 507826176,
       "used": "0 bytes",
       "used_bytes": 0
     },
@@ -167,8 +204,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "492.29 MiB",
-      "available_bytes": 516202496,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -177,14 +214,14 @@
         "nosuid",
         "nodev"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/run": {
-      "available": "491.90 MiB",
-      "available_bytes": 515796992,
+      "available": "491.14 MiB",
+      "available_bytes": 514994176,
       "capacity": "0.08%",
       "device": "run",
       "filesystem": "tmpfs",
@@ -195,14 +232,14 @@
         "relatime",
         "mode=755"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
-      "used": "396.00 KiB",
-      "used_bytes": 405504
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
+      "used": "400.00 KiB",
+      "used_bytes": 409600
     },
     "/run/user/1000": {
-      "available": "98.46 MiB",
-      "available_bytes": 103239680,
+      "available": "98.30 MiB",
+      "available_bytes": 103079936,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -211,19 +248,19 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=100820k",
+        "size=100664k",
         "mode=700",
         "uid=1000",
         "gid=1000"
       ],
-      "size": "98.46 MiB",
-      "size_bytes": 103239680,
+      "size": "98.30 MiB",
+      "size_bytes": 103079936,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/sys/fs/cgroup": {
-      "available": "492.29 MiB",
-      "available_bytes": 516202496,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -234,14 +271,14 @@
         "noexec",
         "mode=755"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/tmp": {
-      "available": "492.29 MiB",
-      "available_bytes": 516202496,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -250,15 +287,15 @@
         "nosuid",
         "nodev"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/vagrant": {
-      "available": "7.77 GiB",
-      "available_bytes": 8340070400,
-      "capacity": "96.67%",
+      "available": "28.43 GiB",
+      "available_bytes": 30522138624,
+      "capacity": "87.81%",
       "device": "vagrant",
       "filesystem": "vboxsf",
       "options": [
@@ -267,10 +304,24 @@
       ],
       "size": "233.10 GiB",
       "size_bytes": 250293325824,
-      "used": "225.34 GiB",
-      "used_bytes": 241953255424
+      "used": "204.68 GiB",
+      "used_bytes": 219771187200
     }
   },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_eth0": "fe80::",
+  "network6_lo": "::1",
+  "network_eth0": "10.0.2.0",
+  "network_lo": "127.0.0.0",
   "networking": {
     "dhcp": "10.0.2.2",
     "fqdn": "archlinux",
@@ -286,15 +337,15 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fe68:5327",
+            "address": "fe80::a00:27ff:feaf:6265",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::"
           }
         ],
         "dhcp": "10.0.2.2",
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fe68:5327",
-        "mac": "08:00:27:68:53:27",
+        "ip6": "fe80::a00:27ff:feaf:6265",
+        "mac": "08:00:27:af:62:65",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -326,8 +377,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fe68:5327",
-    "mac": "08:00:27:68:53:27",
+    "ip6": "fe80::a00:27ff:feaf:6265",
+    "mac": "08:00:27:af:62:65",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -335,39 +386,47 @@
     "network6": "fe80::",
     "primary": "eth0"
   },
+  "operatingsystem": "Archlinux",
+  "operatingsystemmajrelease": "5",
+  "operatingsystemrelease": "5.3.1-arch1-1-ARCH",
   "os": {
     "architecture": "x86_64",
     "family": "Archlinux",
     "hardware": "x86_64",
     "name": "Archlinux",
     "release": {
-      "full": "5.2.13-arch1-1-ARCH",
+      "full": "5.3.1-arch1-1-ARCH",
       "major": "5",
-      "minor": "2"
+      "minor": "3"
     },
     "selinux": {
       "enabled": false
     }
   },
+  "osfamily": "Archlinux",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
-      "partuuid": "a0254c1f-01",
+      "partuuid": "2838d854-01",
       "size": "1.92 GiB",
-      "size_bytes": 2062548992,
-      "uuid": "4ff94364-bf85-4419-8deb-f64d6bdb6696"
+      "size_bytes": 2058354688,
+      "uuid": "eba0ebc5-1db1-4b9c-9b6a-8939751900b2"
     },
     "/dev/sda2": {
       "filesystem": "btrfs",
       "label": "rootfs",
       "mount": "/",
-      "partuuid": "a0254c1f-02",
+      "partuuid": "2838d854-02",
       "size": "18.08 GiB",
-      "size_bytes": 19411238912,
-      "uuid": "f859381e-3d54-4c8e-8a55-8b3702de6b9c"
+      "size_bytes": 19415433216,
+      "uuid": "dee4d316-8cf6-45ce-9182-293d7e7c9103"
     }
   },
-  "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/sbin:/sbin",
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/sbin:/sbin",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+  "processor1": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "unknown",
@@ -377,52 +436,75 @@
     ],
     "physicalcount": 1
   },
+  "productname": "VirtualBox",
   "puppetversion": "6.8.1",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib/ruby/site_ruby/2.6.0",
-    "version": "2.6.4"
+    "version": "2.6.5"
   },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/usr/lib/ruby/site_ruby/2.6.0",
+  "rubyversion": "2.6.5",
+  "selinux": false,
+  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
-        "sha1": "SSHFP 2 1 04e7b6517e9f124486b8b0fc6528aab57c1bc547",
-        "sha256": "SSHFP 2 2 67dbb5f91964b624c06b46bff850e76a42a57dd91cc22a51d44e67f82c5721df"
+        "sha1": "SSHFP 2 1 a0c65effb04d04954bb4d09d53db282f9aca790d",
+        "sha256": "SSHFP 2 2 fd47b56f405a89f9e941d15a1559742389759aad6ea1ab6d965a806efda77b04"
       },
-      "key": "AAAAB3NzaC1kc3MAAACBAMNGIMeVYPwx37+qiZpPxhOB2ss8FEakiNqejneuWW+iria8aLlch1V+2z/gdgePTI6dlPSWMMiCdvLhYZfr9PW5BQ8vZOEdUnlvgb202EmkbP46tnBhIBHV/Qq10rA95yHu/XBsMzLJZtb0UleCCel66aOU6GCsi3jDCHRGWC1dAAAAFQDI2saHjGyWW6GPOvCOsnIX+uuJOQAAAIAfCWY46ehwQzqthU25tFkW8HepxOCgntDBten630VQGD9l2hrFnLf6DfkvCoaqgTtdeZE5nehUoQ6DobivtpAaOx+SdPJi3HaKZz3WwFJ+kOOlj4cqQVHpU5fAlQ8fLlBGsZ8iT8bRLAfWDvqbDWkRkUGCCSFR6bglD8+gVB1UnQAAAIB+CsJGiMJoIysi0nZ1tGJg16hbe5s0hgqQI5AFtRGFzw2X5opagDeXtdFLAIwoOMUTO0J1TWD1lT0DymxYFFMQ/hk0YcuKQnGMJwPE1CUpH9SzJY8rOa9LXfquRoTDoXfeEu3XiHVKuLCoyouPRAy/kOKQCDpS8nLuVLTNkiOxfw==",
+      "key": "AAAAB3NzaC1kc3MAAACBAPiwPPwnebfeoRN1I8OnPYy4HpUZcbWBOY04iwPc2cZuFtkCvuw+gJPkeY6YxeZdNH5kTkZxqWPv2hs8SHWoh4CD+GeG0yfFmKbPYOCCyeU6nmm99SDuFP6R0Ogbx4fsqTkTBFCOZBlRizf+XNCIvIXsY0wu1AaN/1nuw92ukXqBAAAAFQD0Yt4V24h7HTR+sVh+yQPI5H+TawAAAIAb90fPshJB1cOggwklhtfD8lmXpif5k007asLNqsN0ai7vJue3cxxizmXZ5kt6/tYtnFUwW/E7kp7A4Fy0P3uxoFx5QxIBjaBEh0QPlGPvGOJ/L9uH727hVG557Xv4ScKGqOLVK1quYMxkItRwK3xMewGDIrpbvXyCRvXxZgcwswAAAIEA8xikmNqoSMPzS/9uGlDhMoChcqACaALJn+cWRrf3chMc3ox3LH8W6w5koXofXUpN/S481l3hszoNMuX8JRKROWoBBkYaohOtSvuDzJz7Sku3owNKIEvPecFffYQ6CcbPLc0Z0zPQshFo9ny+A2V040JTQxlF+iv1B49CB43xjBs=",
       "type": "ssh-dss"
     },
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 76a64f6b3a843297d10d1397266ca81b5e8b62f7",
-        "sha256": "SSHFP 3 2 15977bc2b7967c141a4b33736aada7798acc97bd06ef871f91c5cadc424bd376"
+        "sha1": "SSHFP 3 1 ea6f05fde6d599793074cc4de596bae3d516b2ed",
+        "sha256": "SSHFP 3 2 77bf426f6a78918845431402dc249f12b80a5d3aa7326564f61c16d9712f180b"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBP9U5gopmw5oeYoXoX4ewE0DH5XbyYs3HLSZgb+CLmzEfCxYRZivMssgsHNKuB3bbo3gw/B8/zSooCDCn4pTaCA=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDfkrDP0uirsivVd1pib+bOL62pluqaXKV3aEs/hVCU3zvar5NILZJXnTBynsUZ8TPCyjKpS0dEW6PlJaoeQGuI=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 5b470e14ec0b17f5b00f36e92032cf8c51d0bfa1",
-        "sha256": "SSHFP 4 2 60f07c5408828bfe20d102cf8a73c977ad11e22977314588353b8e3b520d1bea"
+        "sha1": "SSHFP 4 1 7038e89f3142c34fbaf0b3e86c430662777cb8f8",
+        "sha256": "SSHFP 4 2 9149930a442825395673739a8d1bea14cd7cf0c89c72908c4ef6c67a2557dc59"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIP4jSdQBYtq1ERK8oQa04myrpUF83VyJxAfFCyno1KLi",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIOGmEoGAMVm3P264nKeiz37e/cT1NXlrVvN/+k0XT/ls",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 d1e282567af2608401de29f60197298a8edb617a",
-        "sha256": "SSHFP 1 2 4b6596c1f712bcff21e81147c32d26f4db0428d8562f3328117643fe3e3a1d27"
+        "sha1": "SSHFP 1 1 b836981a1d246e48cd5577e257545ac8ef9c63c3",
+        "sha256": "SSHFP 1 2 d59cdbfccdcde30f959a1dc6195d5e54ab76802800c9fcef6c748ca697735708"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDNRNf7Y8L8GgUzO5EL1ybU7gk/DTOX0F0jW+d4LU8JN5shOjaw2hNdk3Ft78VqgRNDXp5QOCD3XM5DTs/mwabAbvN2G0xc2VY30mW+FQgOxzbw7xGPyX6mtBtxukH2r5bsiEVDl5c3lpMY9AuQJnMRdnTXjeUzX4RQHAQ6TfKI/mDAcjFjNgh69dgOIaz4HcgCJbks4FxRhCCfWtYC9z/+AfSz+yeaef84LdEysJhJ6sQPhTbkEvzvR9WU2UmnctZZS3qZkFrS4ypEVI/q2inFWHHMScHRbaY4LNr5EUIpSb9SO2LwGUN9CxHDsCdnIQr2lqunwfNVdcxJ3HiA4ziadAr0TGb8ryx5MpgioLxkp/hSPqWkuKSQEUYO8mnxlHhZRFhUq5X3ST4OQ4kMERKoY8xfMKAfEpKrpi9+prGAJSy064aUTRk6UQ6i2XhuasgLF9gbN57Sn5PDivERLpQQXO9DcfB2Q7dMmPPT38XwKkXe3kjeI0EftH4GxX7xoHc=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDOZqEYyOU8hXsx0Y/74wkY67LYJfsr9mhgX2B7moQKCinCL9e2jvwhXYNo1dF+mAp2qNa9K96YEG9G6U/Xaf/pCmQ3c0q+omDeInMzLr9mmgH7SZLdTr4NlyTl3sDZvpKepN9+CUxyf5gVYXvAFoFiIecxXC96d2oqvta/ljnJh26tMGfBL3Il8kTxqwMwaImSalLgi9239W+SM4yuk+10QAzpNhr1JlrhWeVHttxQbifx4oRBf88wrZlYBNp1QcPoQbcuFPuJXoPC3J94QmhL7Mh+K2j/IOZf/hZ/ZjYdQwFXPoYellMJwPQy6FjP/ht139MNL7uB53evw6BGwX0e/8dWS1FqToK4djF8ci2LQ03XXXKK6vVy8ypWwHWGNXSd9sehwyfHF0Xylx+4xnWJ1ySoYIHCUiOiusklYFvZC+sgKUK/VFN/q7S98oZDlkwAhNuUrR5gw2uThA83U0rEDqvTavgMWsEycQ0fEi0SNWG40fqrVVPjIx2CYYBeQkU=",
       "type": "ssh-rsa"
     }
   },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBAPiwPPwnebfeoRN1I8OnPYy4HpUZcbWBOY04iwPc2cZuFtkCvuw+gJPkeY6YxeZdNH5kTkZxqWPv2hs8SHWoh4CD+GeG0yfFmKbPYOCCyeU6nmm99SDuFP6R0Ogbx4fsqTkTBFCOZBlRizf+XNCIvIXsY0wu1AaN/1nuw92ukXqBAAAAFQD0Yt4V24h7HTR+sVh+yQPI5H+TawAAAIAb90fPshJB1cOggwklhtfD8lmXpif5k007asLNqsN0ai7vJue3cxxizmXZ5kt6/tYtnFUwW/E7kp7A4Fy0P3uxoFx5QxIBjaBEh0QPlGPvGOJ/L9uH727hVG557Xv4ScKGqOLVK1quYMxkItRwK3xMewGDIrpbvXyCRvXxZgcwswAAAIEA8xikmNqoSMPzS/9uGlDhMoChcqACaALJn+cWRrf3chMc3ox3LH8W6w5koXofXUpN/S481l3hszoNMuX8JRKROWoBBkYaohOtSvuDzJz7Sku3owNKIEvPecFffYQ6CcbPLc0Z0zPQshFo9ny+A2V040JTQxlF+iv1B49CB43xjBs=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDfkrDP0uirsivVd1pib+bOL62pluqaXKV3aEs/hVCU3zvar5NILZJXnTBynsUZ8TPCyjKpS0dEW6PlJaoeQGuI=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIOGmEoGAMVm3P264nKeiz37e/cT1NXlrVvN/+k0XT/ls",
+  "sshfp_dsa": "SSHFP 2 1 a0c65effb04d04954bb4d09d53db282f9aca790d\nSSHFP 2 2 fd47b56f405a89f9e941d15a1559742389759aad6ea1ab6d965a806efda77b04",
+  "sshfp_ecdsa": "SSHFP 3 1 ea6f05fde6d599793074cc4de596bae3d516b2ed\nSSHFP 3 2 77bf426f6a78918845431402dc249f12b80a5d3aa7326564f61c16d9712f180b",
+  "sshfp_ed25519": "SSHFP 4 1 7038e89f3142c34fbaf0b3e86c430662777cb8f8\nSSHFP 4 2 9149930a442825395673739a8d1bea14cd7cf0c89c72908c4ef6c67a2557dc59",
+  "sshfp_rsa": "SSHFP 1 1 b836981a1d246e48cd5577e257545ac8ef9c63c3\nSSHFP 1 2 d59cdbfccdcde30f959a1dc6195d5e54ab76802800c9fcef6c748ca697735708",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDOZqEYyOU8hXsx0Y/74wkY67LYJfsr9mhgX2B7moQKCinCL9e2jvwhXYNo1dF+mAp2qNa9K96YEG9G6U/Xaf/pCmQ3c0q+omDeInMzLr9mmgH7SZLdTr4NlyTl3sDZvpKepN9+CUxyf5gVYXvAFoFiIecxXC96d2oqvta/ljnJh26tMGfBL3Il8kTxqwMwaImSalLgi9239W+SM4yuk+10QAzpNhr1JlrhWeVHttxQbifx4oRBf88wrZlYBNp1QcPoQbcuFPuJXoPC3J94QmhL7Mh+K2j/IOZf/hZ/ZjYdQwFXPoYellMJwPQy6FjP/ht139MNL7uB53evw6BGwX0e/8dWS1FqToK4djF8ci2LQ03XXXKK6vVy8ypWwHWGNXSd9sehwyfHF0Xylx+4xnWJ1ySoYIHCUiOiusklYFvZC+sgKUK/VFN/q7S98oZDlkwAhNuUrR5gw2uThA83U0rEDqvTavgMWsEycQ0fEi0SNWG40fqrVVPjIx2CYYBeQkU=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1960.484375,
+  "swapsize": "1.92 GiB",
+  "swapsize_mb": 1962.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 264,
+    "seconds": 268,
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
+  "uptime": "0:04 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 268,
+  "uuid": "eb6e0002-bde8-4896-b25f-780ea4ce4e2d",
   "virtual": "virtualbox"
 }

--- a/facts/3.11/archlinux-x86_64.facts
+++ b/facts/3.11/archlinux-x86_64.facts
@@ -1,6 +1,23 @@
 {
+  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
+  },
+  "augeasversion": "1.12.0",
+  "bios_release_date": "12/01/2006",
+  "bios_vendor": "innotek GmbH",
+  "bios_version": "VirtualBox",
+  "blockdevice_sda_model": "VBOX HARDDISK",
+  "blockdevice_sda_size": 21474836480,
+  "blockdevice_sda_vendor": "ATA",
+  "blockdevices": "sda",
+  "boardmanufacturer": "Oracle Corporation",
+  "boardproductname": "VirtualBox",
+  "boardserialnumber": "0",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "eth0": "10.0.2.2",
+    "system": "10.0.2.2"
   },
   "disks": {
     "sda": {
@@ -28,15 +45,21 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "5785c0d5-3d4d-4f95-83ea-93e0ad75833c"
+      "uuid": "eb6e0002-bde8-4896-b25f-780ea4ce4e2d"
     }
   },
   "facterversion": "3.11.9",
   "filesystems": "btrfs",
   "fips_enabled": false,
+  "fqdn": "archlinux",
+  "gid": "root",
+  "hardwareisa": "unknown",
+  "hardwaremodel": "x86_64",
+  "hostname": "archlinux",
   "hypervisors": {
     "virtualbox": {}
   },
+  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -44,41 +67,55 @@
     "uid": 0,
     "user": "root"
   },
+  "interfaces": "eth0,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::a00:27ff:feaf:6265",
+  "ipaddress6_eth0": "fe80::a00:27ff:feaf:6265",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
   "kernel": "Linux",
-  "kernelmajversion": "5.2",
-  "kernelrelease": "5.2.13-arch1-1-ARCH",
-  "kernelversion": "5.2.13",
+  "kernelmajversion": "5.3",
+  "kernelrelease": "5.3.1-arch1-1-ARCH",
+  "kernelversion": "5.3.1",
   "load_averages": {
-    "15m": 0.03,
-    "1m": 0.08,
-    "5m": 0.08
+    "15m": 0.25,
+    "1m": 1.07,
+    "5m": 0.57
   },
+  "macaddress": "08:00:27:af:62:65",
+  "macaddress_eth0": "08:00:27:af:62:65",
+  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "1.92 GiB",
-      "available_bytes": 2062544896,
-      "capacity": "0%",
+      "available": "1.91 GiB",
+      "available_bytes": 2055716864,
+      "capacity": "0.13%",
       "total": "1.92 GiB",
-      "total_bytes": 2062544896,
-      "used": "0 bytes",
-      "used_bytes": 0
+      "total_bytes": 2058350592,
+      "used": "2.51 MiB",
+      "used_bytes": 2633728
     },
     "system": {
-      "available": "822.27 MiB",
-      "available_bytes": 862208000,
-      "capacity": "16.49%",
-      "total": "984.58 MiB",
-      "total_bytes": 1032404992,
-      "used": "162.31 MiB",
-      "used_bytes": 170196992
+      "available": "797.25 MiB",
+      "available_bytes": 835977216,
+      "capacity": "18.90%",
+      "total": "983.05 MiB",
+      "total_bytes": 1030807552,
+      "used": "185.80 MiB",
+      "used_bytes": 194830336
     }
   },
+  "memoryfree": "797.25 MiB",
+  "memoryfree_mb": 797.25,
+  "memorysize": "983.05 MiB",
+  "memorysize_mb": 983.0546875,
   "mountpoints": {
     "/": {
-      "available": "16.60 GiB",
-      "available_bytes": 17825533952,
-      "capacity": "8.17%",
+      "available": "16.02 GiB",
+      "available_bytes": 17204256768,
+      "capacity": "11.39%",
       "device": "/dev/sda2",
       "filesystem": "btrfs",
       "options": [
@@ -89,13 +126,13 @@
         "subvol=/"
       ],
       "size": "18.08 GiB",
-      "size_bytes": 19411238912,
-      "used": "1.48 GiB",
-      "used_bytes": 1585704960
+      "size_bytes": 19415433216,
+      "used": "2.06 GiB",
+      "used_bytes": 2211176448
     },
     "/dev": {
-      "available": "485.05 MiB",
-      "available_bytes": 508616704,
+      "available": "484.30 MiB",
+      "available_bytes": 507826176,
       "capacity": "0%",
       "device": "dev",
       "filesystem": "devtmpfs",
@@ -103,12 +140,12 @@
         "rw",
         "nosuid",
         "relatime",
-        "size=496696k",
-        "nr_inodes=124174",
+        "size=495924k",
+        "nr_inodes=123981",
         "mode=755"
       ],
-      "size": "485.05 MiB",
-      "size_bytes": 508616704,
+      "size": "484.30 MiB",
+      "size_bytes": 507826176,
       "used": "0 bytes",
       "used_bytes": 0
     },
@@ -167,8 +204,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "492.29 MiB",
-      "available_bytes": 516202496,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -177,14 +214,14 @@
         "nosuid",
         "nodev"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/run": {
-      "available": "491.90 MiB",
-      "available_bytes": 515796992,
+      "available": "491.14 MiB",
+      "available_bytes": 514994176,
       "capacity": "0.08%",
       "device": "run",
       "filesystem": "tmpfs",
@@ -195,14 +232,14 @@
         "relatime",
         "mode=755"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
-      "used": "396.00 KiB",
-      "used_bytes": 405504
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
+      "used": "400.00 KiB",
+      "used_bytes": 409600
     },
     "/run/user/1000": {
-      "available": "98.46 MiB",
-      "available_bytes": 103239680,
+      "available": "98.30 MiB",
+      "available_bytes": 103079936,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -211,19 +248,19 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=100820k",
+        "size=100664k",
         "mode=700",
         "uid=1000",
         "gid=1000"
       ],
-      "size": "98.46 MiB",
-      "size_bytes": 103239680,
+      "size": "98.30 MiB",
+      "size_bytes": 103079936,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/sys/fs/cgroup": {
-      "available": "492.29 MiB",
-      "available_bytes": 516202496,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -234,14 +271,14 @@
         "noexec",
         "mode=755"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/tmp": {
-      "available": "492.29 MiB",
-      "available_bytes": 516202496,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -250,15 +287,15 @@
         "nosuid",
         "nodev"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/vagrant": {
-      "available": "7.77 GiB",
-      "available_bytes": 8340070400,
-      "capacity": "96.67%",
+      "available": "28.43 GiB",
+      "available_bytes": 30522138624,
+      "capacity": "87.81%",
       "device": "vagrant",
       "filesystem": "vboxsf",
       "options": [
@@ -267,10 +304,24 @@
       ],
       "size": "233.10 GiB",
       "size_bytes": 250293325824,
-      "used": "225.34 GiB",
-      "used_bytes": 241953255424
+      "used": "204.68 GiB",
+      "used_bytes": 219771187200
     }
   },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_eth0": "fe80::",
+  "network6_lo": "::1",
+  "network_eth0": "10.0.2.0",
+  "network_lo": "127.0.0.0",
   "networking": {
     "dhcp": "10.0.2.2",
     "fqdn": "archlinux",
@@ -286,15 +337,15 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fe68:5327",
+            "address": "fe80::a00:27ff:feaf:6265",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::"
           }
         ],
         "dhcp": "10.0.2.2",
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fe68:5327",
-        "mac": "08:00:27:68:53:27",
+        "ip6": "fe80::a00:27ff:feaf:6265",
+        "mac": "08:00:27:af:62:65",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -326,8 +377,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fe68:5327",
-    "mac": "08:00:27:68:53:27",
+    "ip6": "fe80::a00:27ff:feaf:6265",
+    "mac": "08:00:27:af:62:65",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -335,39 +386,47 @@
     "network6": "fe80::",
     "primary": "eth0"
   },
+  "operatingsystem": "Archlinux",
+  "operatingsystemmajrelease": "5",
+  "operatingsystemrelease": "5.3.1-arch1-1-ARCH",
   "os": {
     "architecture": "x86_64",
     "family": "Archlinux",
     "hardware": "x86_64",
     "name": "Archlinux",
     "release": {
-      "full": "5.2.13-arch1-1-ARCH",
+      "full": "5.3.1-arch1-1-ARCH",
       "major": "5",
-      "minor": "2"
+      "minor": "3"
     },
     "selinux": {
       "enabled": false
     }
   },
+  "osfamily": "Archlinux",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
-      "partuuid": "a0254c1f-01",
+      "partuuid": "2838d854-01",
       "size": "1.92 GiB",
-      "size_bytes": 2062548992,
-      "uuid": "4ff94364-bf85-4419-8deb-f64d6bdb6696"
+      "size_bytes": 2058354688,
+      "uuid": "eba0ebc5-1db1-4b9c-9b6a-8939751900b2"
     },
     "/dev/sda2": {
       "filesystem": "btrfs",
       "label": "rootfs",
       "mount": "/",
-      "partuuid": "a0254c1f-02",
+      "partuuid": "2838d854-02",
       "size": "18.08 GiB",
-      "size_bytes": 19411238912,
-      "uuid": "f859381e-3d54-4c8e-8a55-8b3702de6b9c"
+      "size_bytes": 19415433216,
+      "uuid": "dee4d316-8cf6-45ce-9182-293d7e7c9103"
     }
   },
-  "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/sbin:/sbin",
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/sbin:/sbin",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+  "processor1": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "unknown",
@@ -377,52 +436,75 @@
     ],
     "physicalcount": 1
   },
+  "productname": "VirtualBox",
   "puppetversion": "6.8.1",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib/ruby/site_ruby/2.6.0",
-    "version": "2.6.4"
+    "version": "2.6.5"
   },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/usr/lib/ruby/site_ruby/2.6.0",
+  "rubyversion": "2.6.5",
+  "selinux": false,
+  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
-        "sha1": "SSHFP 2 1 04e7b6517e9f124486b8b0fc6528aab57c1bc547",
-        "sha256": "SSHFP 2 2 67dbb5f91964b624c06b46bff850e76a42a57dd91cc22a51d44e67f82c5721df"
+        "sha1": "SSHFP 2 1 a0c65effb04d04954bb4d09d53db282f9aca790d",
+        "sha256": "SSHFP 2 2 fd47b56f405a89f9e941d15a1559742389759aad6ea1ab6d965a806efda77b04"
       },
-      "key": "AAAAB3NzaC1kc3MAAACBAMNGIMeVYPwx37+qiZpPxhOB2ss8FEakiNqejneuWW+iria8aLlch1V+2z/gdgePTI6dlPSWMMiCdvLhYZfr9PW5BQ8vZOEdUnlvgb202EmkbP46tnBhIBHV/Qq10rA95yHu/XBsMzLJZtb0UleCCel66aOU6GCsi3jDCHRGWC1dAAAAFQDI2saHjGyWW6GPOvCOsnIX+uuJOQAAAIAfCWY46ehwQzqthU25tFkW8HepxOCgntDBten630VQGD9l2hrFnLf6DfkvCoaqgTtdeZE5nehUoQ6DobivtpAaOx+SdPJi3HaKZz3WwFJ+kOOlj4cqQVHpU5fAlQ8fLlBGsZ8iT8bRLAfWDvqbDWkRkUGCCSFR6bglD8+gVB1UnQAAAIB+CsJGiMJoIysi0nZ1tGJg16hbe5s0hgqQI5AFtRGFzw2X5opagDeXtdFLAIwoOMUTO0J1TWD1lT0DymxYFFMQ/hk0YcuKQnGMJwPE1CUpH9SzJY8rOa9LXfquRoTDoXfeEu3XiHVKuLCoyouPRAy/kOKQCDpS8nLuVLTNkiOxfw==",
+      "key": "AAAAB3NzaC1kc3MAAACBAPiwPPwnebfeoRN1I8OnPYy4HpUZcbWBOY04iwPc2cZuFtkCvuw+gJPkeY6YxeZdNH5kTkZxqWPv2hs8SHWoh4CD+GeG0yfFmKbPYOCCyeU6nmm99SDuFP6R0Ogbx4fsqTkTBFCOZBlRizf+XNCIvIXsY0wu1AaN/1nuw92ukXqBAAAAFQD0Yt4V24h7HTR+sVh+yQPI5H+TawAAAIAb90fPshJB1cOggwklhtfD8lmXpif5k007asLNqsN0ai7vJue3cxxizmXZ5kt6/tYtnFUwW/E7kp7A4Fy0P3uxoFx5QxIBjaBEh0QPlGPvGOJ/L9uH727hVG557Xv4ScKGqOLVK1quYMxkItRwK3xMewGDIrpbvXyCRvXxZgcwswAAAIEA8xikmNqoSMPzS/9uGlDhMoChcqACaALJn+cWRrf3chMc3ox3LH8W6w5koXofXUpN/S481l3hszoNMuX8JRKROWoBBkYaohOtSvuDzJz7Sku3owNKIEvPecFffYQ6CcbPLc0Z0zPQshFo9ny+A2V040JTQxlF+iv1B49CB43xjBs=",
       "type": "ssh-dss"
     },
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 76a64f6b3a843297d10d1397266ca81b5e8b62f7",
-        "sha256": "SSHFP 3 2 15977bc2b7967c141a4b33736aada7798acc97bd06ef871f91c5cadc424bd376"
+        "sha1": "SSHFP 3 1 ea6f05fde6d599793074cc4de596bae3d516b2ed",
+        "sha256": "SSHFP 3 2 77bf426f6a78918845431402dc249f12b80a5d3aa7326564f61c16d9712f180b"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBP9U5gopmw5oeYoXoX4ewE0DH5XbyYs3HLSZgb+CLmzEfCxYRZivMssgsHNKuB3bbo3gw/B8/zSooCDCn4pTaCA=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDfkrDP0uirsivVd1pib+bOL62pluqaXKV3aEs/hVCU3zvar5NILZJXnTBynsUZ8TPCyjKpS0dEW6PlJaoeQGuI=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 5b470e14ec0b17f5b00f36e92032cf8c51d0bfa1",
-        "sha256": "SSHFP 4 2 60f07c5408828bfe20d102cf8a73c977ad11e22977314588353b8e3b520d1bea"
+        "sha1": "SSHFP 4 1 7038e89f3142c34fbaf0b3e86c430662777cb8f8",
+        "sha256": "SSHFP 4 2 9149930a442825395673739a8d1bea14cd7cf0c89c72908c4ef6c67a2557dc59"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIP4jSdQBYtq1ERK8oQa04myrpUF83VyJxAfFCyno1KLi",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIOGmEoGAMVm3P264nKeiz37e/cT1NXlrVvN/+k0XT/ls",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 d1e282567af2608401de29f60197298a8edb617a",
-        "sha256": "SSHFP 1 2 4b6596c1f712bcff21e81147c32d26f4db0428d8562f3328117643fe3e3a1d27"
+        "sha1": "SSHFP 1 1 b836981a1d246e48cd5577e257545ac8ef9c63c3",
+        "sha256": "SSHFP 1 2 d59cdbfccdcde30f959a1dc6195d5e54ab76802800c9fcef6c748ca697735708"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDNRNf7Y8L8GgUzO5EL1ybU7gk/DTOX0F0jW+d4LU8JN5shOjaw2hNdk3Ft78VqgRNDXp5QOCD3XM5DTs/mwabAbvN2G0xc2VY30mW+FQgOxzbw7xGPyX6mtBtxukH2r5bsiEVDl5c3lpMY9AuQJnMRdnTXjeUzX4RQHAQ6TfKI/mDAcjFjNgh69dgOIaz4HcgCJbks4FxRhCCfWtYC9z/+AfSz+yeaef84LdEysJhJ6sQPhTbkEvzvR9WU2UmnctZZS3qZkFrS4ypEVI/q2inFWHHMScHRbaY4LNr5EUIpSb9SO2LwGUN9CxHDsCdnIQr2lqunwfNVdcxJ3HiA4ziadAr0TGb8ryx5MpgioLxkp/hSPqWkuKSQEUYO8mnxlHhZRFhUq5X3ST4OQ4kMERKoY8xfMKAfEpKrpi9+prGAJSy064aUTRk6UQ6i2XhuasgLF9gbN57Sn5PDivERLpQQXO9DcfB2Q7dMmPPT38XwKkXe3kjeI0EftH4GxX7xoHc=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDOZqEYyOU8hXsx0Y/74wkY67LYJfsr9mhgX2B7moQKCinCL9e2jvwhXYNo1dF+mAp2qNa9K96YEG9G6U/Xaf/pCmQ3c0q+omDeInMzLr9mmgH7SZLdTr4NlyTl3sDZvpKepN9+CUxyf5gVYXvAFoFiIecxXC96d2oqvta/ljnJh26tMGfBL3Il8kTxqwMwaImSalLgi9239W+SM4yuk+10QAzpNhr1JlrhWeVHttxQbifx4oRBf88wrZlYBNp1QcPoQbcuFPuJXoPC3J94QmhL7Mh+K2j/IOZf/hZ/ZjYdQwFXPoYellMJwPQy6FjP/ht139MNL7uB53evw6BGwX0e/8dWS1FqToK4djF8ci2LQ03XXXKK6vVy8ypWwHWGNXSd9sehwyfHF0Xylx+4xnWJ1ySoYIHCUiOiusklYFvZC+sgKUK/VFN/q7S98oZDlkwAhNuUrR5gw2uThA83U0rEDqvTavgMWsEycQ0fEi0SNWG40fqrVVPjIx2CYYBeQkU=",
       "type": "ssh-rsa"
     }
   },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBAPiwPPwnebfeoRN1I8OnPYy4HpUZcbWBOY04iwPc2cZuFtkCvuw+gJPkeY6YxeZdNH5kTkZxqWPv2hs8SHWoh4CD+GeG0yfFmKbPYOCCyeU6nmm99SDuFP6R0Ogbx4fsqTkTBFCOZBlRizf+XNCIvIXsY0wu1AaN/1nuw92ukXqBAAAAFQD0Yt4V24h7HTR+sVh+yQPI5H+TawAAAIAb90fPshJB1cOggwklhtfD8lmXpif5k007asLNqsN0ai7vJue3cxxizmXZ5kt6/tYtnFUwW/E7kp7A4Fy0P3uxoFx5QxIBjaBEh0QPlGPvGOJ/L9uH727hVG557Xv4ScKGqOLVK1quYMxkItRwK3xMewGDIrpbvXyCRvXxZgcwswAAAIEA8xikmNqoSMPzS/9uGlDhMoChcqACaALJn+cWRrf3chMc3ox3LH8W6w5koXofXUpN/S481l3hszoNMuX8JRKROWoBBkYaohOtSvuDzJz7Sku3owNKIEvPecFffYQ6CcbPLc0Z0zPQshFo9ny+A2V040JTQxlF+iv1B49CB43xjBs=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDfkrDP0uirsivVd1pib+bOL62pluqaXKV3aEs/hVCU3zvar5NILZJXnTBynsUZ8TPCyjKpS0dEW6PlJaoeQGuI=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIOGmEoGAMVm3P264nKeiz37e/cT1NXlrVvN/+k0XT/ls",
+  "sshfp_dsa": "SSHFP 2 1 a0c65effb04d04954bb4d09d53db282f9aca790d\nSSHFP 2 2 fd47b56f405a89f9e941d15a1559742389759aad6ea1ab6d965a806efda77b04",
+  "sshfp_ecdsa": "SSHFP 3 1 ea6f05fde6d599793074cc4de596bae3d516b2ed\nSSHFP 3 2 77bf426f6a78918845431402dc249f12b80a5d3aa7326564f61c16d9712f180b",
+  "sshfp_ed25519": "SSHFP 4 1 7038e89f3142c34fbaf0b3e86c430662777cb8f8\nSSHFP 4 2 9149930a442825395673739a8d1bea14cd7cf0c89c72908c4ef6c67a2557dc59",
+  "sshfp_rsa": "SSHFP 1 1 b836981a1d246e48cd5577e257545ac8ef9c63c3\nSSHFP 1 2 d59cdbfccdcde30f959a1dc6195d5e54ab76802800c9fcef6c748ca697735708",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDOZqEYyOU8hXsx0Y/74wkY67LYJfsr9mhgX2B7moQKCinCL9e2jvwhXYNo1dF+mAp2qNa9K96YEG9G6U/Xaf/pCmQ3c0q+omDeInMzLr9mmgH7SZLdTr4NlyTl3sDZvpKepN9+CUxyf5gVYXvAFoFiIecxXC96d2oqvta/ljnJh26tMGfBL3Il8kTxqwMwaImSalLgi9239W+SM4yuk+10QAzpNhr1JlrhWeVHttxQbifx4oRBf88wrZlYBNp1QcPoQbcuFPuJXoPC3J94QmhL7Mh+K2j/IOZf/hZ/ZjYdQwFXPoYellMJwPQy6FjP/ht139MNL7uB53evw6BGwX0e/8dWS1FqToK4djF8ci2LQ03XXXKK6vVy8ypWwHWGNXSd9sehwyfHF0Xylx+4xnWJ1ySoYIHCUiOiusklYFvZC+sgKUK/VFN/q7S98oZDlkwAhNuUrR5gw2uThA83U0rEDqvTavgMWsEycQ0fEi0SNWG40fqrVVPjIx2CYYBeQkU=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1960.484375,
+  "swapsize": "1.92 GiB",
+  "swapsize_mb": 1962.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 264,
+    "seconds": 268,
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
+  "uptime": "0:04 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 268,
+  "uuid": "eb6e0002-bde8-4896-b25f-780ea4ce4e2d",
   "virtual": "virtualbox"
 }

--- a/facts/3.12/archlinux-x86_64.facts
+++ b/facts/3.12/archlinux-x86_64.facts
@@ -1,6 +1,23 @@
 {
+  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
+  },
+  "augeasversion": "1.12.0",
+  "bios_release_date": "12/01/2006",
+  "bios_vendor": "innotek GmbH",
+  "bios_version": "VirtualBox",
+  "blockdevice_sda_model": "VBOX HARDDISK",
+  "blockdevice_sda_size": 21474836480,
+  "blockdevice_sda_vendor": "ATA",
+  "blockdevices": "sda",
+  "boardmanufacturer": "Oracle Corporation",
+  "boardproductname": "VirtualBox",
+  "boardserialnumber": "0",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "eth0": "10.0.2.2",
+    "system": "10.0.2.2"
   },
   "disks": {
     "sda": {
@@ -28,15 +45,21 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "5785c0d5-3d4d-4f95-83ea-93e0ad75833c"
+      "uuid": "eb6e0002-bde8-4896-b25f-780ea4ce4e2d"
     }
   },
   "facterversion": "3.12.5",
   "filesystems": "btrfs",
   "fips_enabled": false,
+  "fqdn": "archlinux",
+  "gid": "root",
+  "hardwareisa": "unknown",
+  "hardwaremodel": "x86_64",
+  "hostname": "archlinux",
   "hypervisors": {
     "virtualbox": {}
   },
+  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -44,41 +67,55 @@
     "uid": 0,
     "user": "root"
   },
+  "interfaces": "eth0,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::a00:27ff:feaf:6265",
+  "ipaddress6_eth0": "fe80::a00:27ff:feaf:6265",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
   "kernel": "Linux",
-  "kernelmajversion": "5.2",
-  "kernelrelease": "5.2.13-arch1-1-ARCH",
-  "kernelversion": "5.2.13",
+  "kernelmajversion": "5.3",
+  "kernelrelease": "5.3.1-arch1-1-ARCH",
+  "kernelversion": "5.3.1",
   "load_averages": {
-    "15m": 0.03,
-    "1m": 0.08,
-    "5m": 0.08
+    "15m": 0.25,
+    "1m": 1.07,
+    "5m": 0.57
   },
+  "macaddress": "08:00:27:af:62:65",
+  "macaddress_eth0": "08:00:27:af:62:65",
+  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "1.92 GiB",
-      "available_bytes": 2062544896,
-      "capacity": "0%",
+      "available": "1.91 GiB",
+      "available_bytes": 2055716864,
+      "capacity": "0.13%",
       "total": "1.92 GiB",
-      "total_bytes": 2062544896,
-      "used": "0 bytes",
-      "used_bytes": 0
+      "total_bytes": 2058350592,
+      "used": "2.51 MiB",
+      "used_bytes": 2633728
     },
     "system": {
-      "available": "822.27 MiB",
-      "available_bytes": 862208000,
-      "capacity": "16.49%",
-      "total": "984.58 MiB",
-      "total_bytes": 1032404992,
-      "used": "162.31 MiB",
-      "used_bytes": 170196992
+      "available": "797.25 MiB",
+      "available_bytes": 835977216,
+      "capacity": "18.90%",
+      "total": "983.05 MiB",
+      "total_bytes": 1030807552,
+      "used": "185.80 MiB",
+      "used_bytes": 194830336
     }
   },
+  "memoryfree": "797.25 MiB",
+  "memoryfree_mb": 797.25,
+  "memorysize": "983.05 MiB",
+  "memorysize_mb": 983.0546875,
   "mountpoints": {
     "/": {
-      "available": "16.60 GiB",
-      "available_bytes": 17825533952,
-      "capacity": "8.17%",
+      "available": "16.02 GiB",
+      "available_bytes": 17204256768,
+      "capacity": "11.39%",
       "device": "/dev/sda2",
       "filesystem": "btrfs",
       "options": [
@@ -89,13 +126,13 @@
         "subvol=/"
       ],
       "size": "18.08 GiB",
-      "size_bytes": 19411238912,
-      "used": "1.48 GiB",
-      "used_bytes": 1585704960
+      "size_bytes": 19415433216,
+      "used": "2.06 GiB",
+      "used_bytes": 2211176448
     },
     "/dev": {
-      "available": "485.05 MiB",
-      "available_bytes": 508616704,
+      "available": "484.30 MiB",
+      "available_bytes": 507826176,
       "capacity": "0%",
       "device": "dev",
       "filesystem": "devtmpfs",
@@ -103,12 +140,12 @@
         "rw",
         "nosuid",
         "relatime",
-        "size=496696k",
-        "nr_inodes=124174",
+        "size=495924k",
+        "nr_inodes=123981",
         "mode=755"
       ],
-      "size": "485.05 MiB",
-      "size_bytes": 508616704,
+      "size": "484.30 MiB",
+      "size_bytes": 507826176,
       "used": "0 bytes",
       "used_bytes": 0
     },
@@ -167,8 +204,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "492.29 MiB",
-      "available_bytes": 516202496,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -177,14 +214,14 @@
         "nosuid",
         "nodev"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/run": {
-      "available": "491.90 MiB",
-      "available_bytes": 515796992,
+      "available": "491.14 MiB",
+      "available_bytes": 514994176,
       "capacity": "0.08%",
       "device": "run",
       "filesystem": "tmpfs",
@@ -195,14 +232,14 @@
         "relatime",
         "mode=755"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
-      "used": "396.00 KiB",
-      "used_bytes": 405504
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
+      "used": "400.00 KiB",
+      "used_bytes": 409600
     },
     "/run/user/1000": {
-      "available": "98.46 MiB",
-      "available_bytes": 103239680,
+      "available": "98.30 MiB",
+      "available_bytes": 103079936,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -211,19 +248,19 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=100820k",
+        "size=100664k",
         "mode=700",
         "uid=1000",
         "gid=1000"
       ],
-      "size": "98.46 MiB",
-      "size_bytes": 103239680,
+      "size": "98.30 MiB",
+      "size_bytes": 103079936,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/sys/fs/cgroup": {
-      "available": "492.29 MiB",
-      "available_bytes": 516202496,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -234,14 +271,14 @@
         "noexec",
         "mode=755"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/tmp": {
-      "available": "492.29 MiB",
-      "available_bytes": 516202496,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -250,15 +287,15 @@
         "nosuid",
         "nodev"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/vagrant": {
-      "available": "7.77 GiB",
-      "available_bytes": 8340070400,
-      "capacity": "96.67%",
+      "available": "28.43 GiB",
+      "available_bytes": 30522138624,
+      "capacity": "87.81%",
       "device": "vagrant",
       "filesystem": "vboxsf",
       "options": [
@@ -267,10 +304,24 @@
       ],
       "size": "233.10 GiB",
       "size_bytes": 250293325824,
-      "used": "225.34 GiB",
-      "used_bytes": 241953255424
+      "used": "204.68 GiB",
+      "used_bytes": 219771187200
     }
   },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_eth0": "fe80::",
+  "network6_lo": "::1",
+  "network_eth0": "10.0.2.0",
+  "network_lo": "127.0.0.0",
   "networking": {
     "dhcp": "10.0.2.2",
     "fqdn": "archlinux",
@@ -286,15 +337,15 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fe68:5327",
+            "address": "fe80::a00:27ff:feaf:6265",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::"
           }
         ],
         "dhcp": "10.0.2.2",
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fe68:5327",
-        "mac": "08:00:27:68:53:27",
+        "ip6": "fe80::a00:27ff:feaf:6265",
+        "mac": "08:00:27:af:62:65",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -326,8 +377,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fe68:5327",
-    "mac": "08:00:27:68:53:27",
+    "ip6": "fe80::a00:27ff:feaf:6265",
+    "mac": "08:00:27:af:62:65",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -335,39 +386,47 @@
     "network6": "fe80::",
     "primary": "eth0"
   },
+  "operatingsystem": "Archlinux",
+  "operatingsystemmajrelease": "5",
+  "operatingsystemrelease": "5.3.1-arch1-1-ARCH",
   "os": {
     "architecture": "x86_64",
     "family": "Archlinux",
     "hardware": "x86_64",
     "name": "Archlinux",
     "release": {
-      "full": "5.2.13-arch1-1-ARCH",
+      "full": "5.3.1-arch1-1-ARCH",
       "major": "5",
-      "minor": "2"
+      "minor": "3"
     },
     "selinux": {
       "enabled": false
     }
   },
+  "osfamily": "Archlinux",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
-      "partuuid": "a0254c1f-01",
+      "partuuid": "2838d854-01",
       "size": "1.92 GiB",
-      "size_bytes": 2062548992,
-      "uuid": "4ff94364-bf85-4419-8deb-f64d6bdb6696"
+      "size_bytes": 2058354688,
+      "uuid": "eba0ebc5-1db1-4b9c-9b6a-8939751900b2"
     },
     "/dev/sda2": {
       "filesystem": "btrfs",
       "label": "rootfs",
       "mount": "/",
-      "partuuid": "a0254c1f-02",
+      "partuuid": "2838d854-02",
       "size": "18.08 GiB",
-      "size_bytes": 19411238912,
-      "uuid": "f859381e-3d54-4c8e-8a55-8b3702de6b9c"
+      "size_bytes": 19415433216,
+      "uuid": "dee4d316-8cf6-45ce-9182-293d7e7c9103"
     }
   },
-  "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/sbin:/sbin",
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/sbin:/sbin",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+  "processor1": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "unknown",
@@ -377,52 +436,75 @@
     ],
     "physicalcount": 1
   },
+  "productname": "VirtualBox",
   "puppetversion": "6.8.1",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib/ruby/site_ruby/2.6.0",
-    "version": "2.6.4"
+    "version": "2.6.5"
   },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/usr/lib/ruby/site_ruby/2.6.0",
+  "rubyversion": "2.6.5",
+  "selinux": false,
+  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
-        "sha1": "SSHFP 2 1 04e7b6517e9f124486b8b0fc6528aab57c1bc547",
-        "sha256": "SSHFP 2 2 67dbb5f91964b624c06b46bff850e76a42a57dd91cc22a51d44e67f82c5721df"
+        "sha1": "SSHFP 2 1 a0c65effb04d04954bb4d09d53db282f9aca790d",
+        "sha256": "SSHFP 2 2 fd47b56f405a89f9e941d15a1559742389759aad6ea1ab6d965a806efda77b04"
       },
-      "key": "AAAAB3NzaC1kc3MAAACBAMNGIMeVYPwx37+qiZpPxhOB2ss8FEakiNqejneuWW+iria8aLlch1V+2z/gdgePTI6dlPSWMMiCdvLhYZfr9PW5BQ8vZOEdUnlvgb202EmkbP46tnBhIBHV/Qq10rA95yHu/XBsMzLJZtb0UleCCel66aOU6GCsi3jDCHRGWC1dAAAAFQDI2saHjGyWW6GPOvCOsnIX+uuJOQAAAIAfCWY46ehwQzqthU25tFkW8HepxOCgntDBten630VQGD9l2hrFnLf6DfkvCoaqgTtdeZE5nehUoQ6DobivtpAaOx+SdPJi3HaKZz3WwFJ+kOOlj4cqQVHpU5fAlQ8fLlBGsZ8iT8bRLAfWDvqbDWkRkUGCCSFR6bglD8+gVB1UnQAAAIB+CsJGiMJoIysi0nZ1tGJg16hbe5s0hgqQI5AFtRGFzw2X5opagDeXtdFLAIwoOMUTO0J1TWD1lT0DymxYFFMQ/hk0YcuKQnGMJwPE1CUpH9SzJY8rOa9LXfquRoTDoXfeEu3XiHVKuLCoyouPRAy/kOKQCDpS8nLuVLTNkiOxfw==",
+      "key": "AAAAB3NzaC1kc3MAAACBAPiwPPwnebfeoRN1I8OnPYy4HpUZcbWBOY04iwPc2cZuFtkCvuw+gJPkeY6YxeZdNH5kTkZxqWPv2hs8SHWoh4CD+GeG0yfFmKbPYOCCyeU6nmm99SDuFP6R0Ogbx4fsqTkTBFCOZBlRizf+XNCIvIXsY0wu1AaN/1nuw92ukXqBAAAAFQD0Yt4V24h7HTR+sVh+yQPI5H+TawAAAIAb90fPshJB1cOggwklhtfD8lmXpif5k007asLNqsN0ai7vJue3cxxizmXZ5kt6/tYtnFUwW/E7kp7A4Fy0P3uxoFx5QxIBjaBEh0QPlGPvGOJ/L9uH727hVG557Xv4ScKGqOLVK1quYMxkItRwK3xMewGDIrpbvXyCRvXxZgcwswAAAIEA8xikmNqoSMPzS/9uGlDhMoChcqACaALJn+cWRrf3chMc3ox3LH8W6w5koXofXUpN/S481l3hszoNMuX8JRKROWoBBkYaohOtSvuDzJz7Sku3owNKIEvPecFffYQ6CcbPLc0Z0zPQshFo9ny+A2V040JTQxlF+iv1B49CB43xjBs=",
       "type": "ssh-dss"
     },
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 76a64f6b3a843297d10d1397266ca81b5e8b62f7",
-        "sha256": "SSHFP 3 2 15977bc2b7967c141a4b33736aada7798acc97bd06ef871f91c5cadc424bd376"
+        "sha1": "SSHFP 3 1 ea6f05fde6d599793074cc4de596bae3d516b2ed",
+        "sha256": "SSHFP 3 2 77bf426f6a78918845431402dc249f12b80a5d3aa7326564f61c16d9712f180b"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBP9U5gopmw5oeYoXoX4ewE0DH5XbyYs3HLSZgb+CLmzEfCxYRZivMssgsHNKuB3bbo3gw/B8/zSooCDCn4pTaCA=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDfkrDP0uirsivVd1pib+bOL62pluqaXKV3aEs/hVCU3zvar5NILZJXnTBynsUZ8TPCyjKpS0dEW6PlJaoeQGuI=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 5b470e14ec0b17f5b00f36e92032cf8c51d0bfa1",
-        "sha256": "SSHFP 4 2 60f07c5408828bfe20d102cf8a73c977ad11e22977314588353b8e3b520d1bea"
+        "sha1": "SSHFP 4 1 7038e89f3142c34fbaf0b3e86c430662777cb8f8",
+        "sha256": "SSHFP 4 2 9149930a442825395673739a8d1bea14cd7cf0c89c72908c4ef6c67a2557dc59"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIP4jSdQBYtq1ERK8oQa04myrpUF83VyJxAfFCyno1KLi",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIOGmEoGAMVm3P264nKeiz37e/cT1NXlrVvN/+k0XT/ls",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 d1e282567af2608401de29f60197298a8edb617a",
-        "sha256": "SSHFP 1 2 4b6596c1f712bcff21e81147c32d26f4db0428d8562f3328117643fe3e3a1d27"
+        "sha1": "SSHFP 1 1 b836981a1d246e48cd5577e257545ac8ef9c63c3",
+        "sha256": "SSHFP 1 2 d59cdbfccdcde30f959a1dc6195d5e54ab76802800c9fcef6c748ca697735708"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDNRNf7Y8L8GgUzO5EL1ybU7gk/DTOX0F0jW+d4LU8JN5shOjaw2hNdk3Ft78VqgRNDXp5QOCD3XM5DTs/mwabAbvN2G0xc2VY30mW+FQgOxzbw7xGPyX6mtBtxukH2r5bsiEVDl5c3lpMY9AuQJnMRdnTXjeUzX4RQHAQ6TfKI/mDAcjFjNgh69dgOIaz4HcgCJbks4FxRhCCfWtYC9z/+AfSz+yeaef84LdEysJhJ6sQPhTbkEvzvR9WU2UmnctZZS3qZkFrS4ypEVI/q2inFWHHMScHRbaY4LNr5EUIpSb9SO2LwGUN9CxHDsCdnIQr2lqunwfNVdcxJ3HiA4ziadAr0TGb8ryx5MpgioLxkp/hSPqWkuKSQEUYO8mnxlHhZRFhUq5X3ST4OQ4kMERKoY8xfMKAfEpKrpi9+prGAJSy064aUTRk6UQ6i2XhuasgLF9gbN57Sn5PDivERLpQQXO9DcfB2Q7dMmPPT38XwKkXe3kjeI0EftH4GxX7xoHc=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDOZqEYyOU8hXsx0Y/74wkY67LYJfsr9mhgX2B7moQKCinCL9e2jvwhXYNo1dF+mAp2qNa9K96YEG9G6U/Xaf/pCmQ3c0q+omDeInMzLr9mmgH7SZLdTr4NlyTl3sDZvpKepN9+CUxyf5gVYXvAFoFiIecxXC96d2oqvta/ljnJh26tMGfBL3Il8kTxqwMwaImSalLgi9239W+SM4yuk+10QAzpNhr1JlrhWeVHttxQbifx4oRBf88wrZlYBNp1QcPoQbcuFPuJXoPC3J94QmhL7Mh+K2j/IOZf/hZ/ZjYdQwFXPoYellMJwPQy6FjP/ht139MNL7uB53evw6BGwX0e/8dWS1FqToK4djF8ci2LQ03XXXKK6vVy8ypWwHWGNXSd9sehwyfHF0Xylx+4xnWJ1ySoYIHCUiOiusklYFvZC+sgKUK/VFN/q7S98oZDlkwAhNuUrR5gw2uThA83U0rEDqvTavgMWsEycQ0fEi0SNWG40fqrVVPjIx2CYYBeQkU=",
       "type": "ssh-rsa"
     }
   },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBAPiwPPwnebfeoRN1I8OnPYy4HpUZcbWBOY04iwPc2cZuFtkCvuw+gJPkeY6YxeZdNH5kTkZxqWPv2hs8SHWoh4CD+GeG0yfFmKbPYOCCyeU6nmm99SDuFP6R0Ogbx4fsqTkTBFCOZBlRizf+XNCIvIXsY0wu1AaN/1nuw92ukXqBAAAAFQD0Yt4V24h7HTR+sVh+yQPI5H+TawAAAIAb90fPshJB1cOggwklhtfD8lmXpif5k007asLNqsN0ai7vJue3cxxizmXZ5kt6/tYtnFUwW/E7kp7A4Fy0P3uxoFx5QxIBjaBEh0QPlGPvGOJ/L9uH727hVG557Xv4ScKGqOLVK1quYMxkItRwK3xMewGDIrpbvXyCRvXxZgcwswAAAIEA8xikmNqoSMPzS/9uGlDhMoChcqACaALJn+cWRrf3chMc3ox3LH8W6w5koXofXUpN/S481l3hszoNMuX8JRKROWoBBkYaohOtSvuDzJz7Sku3owNKIEvPecFffYQ6CcbPLc0Z0zPQshFo9ny+A2V040JTQxlF+iv1B49CB43xjBs=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDfkrDP0uirsivVd1pib+bOL62pluqaXKV3aEs/hVCU3zvar5NILZJXnTBynsUZ8TPCyjKpS0dEW6PlJaoeQGuI=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIOGmEoGAMVm3P264nKeiz37e/cT1NXlrVvN/+k0XT/ls",
+  "sshfp_dsa": "SSHFP 2 1 a0c65effb04d04954bb4d09d53db282f9aca790d\nSSHFP 2 2 fd47b56f405a89f9e941d15a1559742389759aad6ea1ab6d965a806efda77b04",
+  "sshfp_ecdsa": "SSHFP 3 1 ea6f05fde6d599793074cc4de596bae3d516b2ed\nSSHFP 3 2 77bf426f6a78918845431402dc249f12b80a5d3aa7326564f61c16d9712f180b",
+  "sshfp_ed25519": "SSHFP 4 1 7038e89f3142c34fbaf0b3e86c430662777cb8f8\nSSHFP 4 2 9149930a442825395673739a8d1bea14cd7cf0c89c72908c4ef6c67a2557dc59",
+  "sshfp_rsa": "SSHFP 1 1 b836981a1d246e48cd5577e257545ac8ef9c63c3\nSSHFP 1 2 d59cdbfccdcde30f959a1dc6195d5e54ab76802800c9fcef6c748ca697735708",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDOZqEYyOU8hXsx0Y/74wkY67LYJfsr9mhgX2B7moQKCinCL9e2jvwhXYNo1dF+mAp2qNa9K96YEG9G6U/Xaf/pCmQ3c0q+omDeInMzLr9mmgH7SZLdTr4NlyTl3sDZvpKepN9+CUxyf5gVYXvAFoFiIecxXC96d2oqvta/ljnJh26tMGfBL3Il8kTxqwMwaImSalLgi9239W+SM4yuk+10QAzpNhr1JlrhWeVHttxQbifx4oRBf88wrZlYBNp1QcPoQbcuFPuJXoPC3J94QmhL7Mh+K2j/IOZf/hZ/ZjYdQwFXPoYellMJwPQy6FjP/ht139MNL7uB53evw6BGwX0e/8dWS1FqToK4djF8ci2LQ03XXXKK6vVy8ypWwHWGNXSd9sehwyfHF0Xylx+4xnWJ1ySoYIHCUiOiusklYFvZC+sgKUK/VFN/q7S98oZDlkwAhNuUrR5gw2uThA83U0rEDqvTavgMWsEycQ0fEi0SNWG40fqrVVPjIx2CYYBeQkU=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1960.484375,
+  "swapsize": "1.92 GiB",
+  "swapsize_mb": 1962.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 264,
+    "seconds": 268,
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
+  "uptime": "0:04 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 268,
+  "uuid": "eb6e0002-bde8-4896-b25f-780ea4ce4e2d",
   "virtual": "virtualbox"
 }

--- a/facts/3.14/VirtuozzoLinux-7-x86_64.facts
+++ b/facts/3.14/VirtuozzoLinux-7-x86_64.facts
@@ -1,7 +1,24 @@
 {
   "aio_agent_version": "6.10.1",
+  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
+  },
+  "augeasversion": "1.12.0",
+  "bios_release_date": "08/15/2019",
+  "bios_vendor": "Dell Inc.",
+  "bios_version": "2.3.10",
+  "blockdevice_sda_model": "PERC H730P Adp",
+  "blockdevice_sda_size": 14334319132672,
+  "blockdevice_sda_vendor": "DELL",
+  "blockdevices": "sda",
+  "boardmanufacturer": "Dell Inc.",
+  "boardproductname": "EUHRV",
+  "boardserialnumber": "EHRJIOUE",
+  "chassistype": "Rack Mount Chassis",
+  "dhcp_servers": {
+    "eth0": "169.255.254.1",
+    "system": "169.255.254.1"
   },
   "disks": {
     "sda": {
@@ -20,7 +37,7 @@
     "board": {
       "manufacturer": "Dell Inc.",
       "product": "EUHRV",
-      "serial_number": "JKSJHRKEJHR"
+      "serial_number": "EHRJIOUE"
     },
     "chassis": {
       "type": "Rack Mount Chassis"
@@ -32,9 +49,15 @@
       "uuid": "9ee62364-bcb9-48b8-b808-5f37c426a9d3"
     }
   },
+  "domain": "example.com",
   "facterversion": "3.14.5",
   "filesystems": "btrfs,ext2,ext3,ext4,msdos,vfat,xfs",
   "fips_enabled": false,
+  "fqdn": "awesome.example.com",
+  "gid": "root",
+  "hardwareisa": "x86_64",
+  "hardwaremodel": "x86_64",
+  "hostname": "awesome",
   "hypervisors": {
     "openvz": {
       "cloudlinux": false,
@@ -42,6 +65,7 @@
       "id": 0
     }
   },
+  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -49,6 +73,13 @@
     "uid": 0,
     "user": "root"
   },
+  "interfaces": "eth0,lo",
+  "ipaddress": "192.168.178.2",
+  "ipaddress6": "fe80::4ed9:8fff:fe8e:3a5d",
+  "ipaddress6_eth0": "fe80::4ed9:8fff:fe8e:3a5d",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "192.168.178.2",
+  "ipaddress_lo": "127.0.0.1",
   "is_virtual": false,
   "kernel": "Linux",
   "kernelmajversion": "3.10",
@@ -56,25 +87,32 @@
   "kernelversion": "3.10.0",
   "load_averages": {
     "15m": 0.05,
-    "1m": 0.05,
-    "5m": 0.06
+    "1m": 0.01,
+    "5m": 0.03
   },
+  "macaddress": "4c:d9:8f:8e:3a:5d",
+  "macaddress_eth0": "4c:d9:8f:8e:3a:5d",
+  "manufacturer": "Dell Inc.",
   "memory": {
     "system": {
-      "available": "372.83 GiB",
-      "available_bytes": 400322248704,
-      "capacity": "0.88%",
+      "available": "372.29 GiB",
+      "available_bytes": 399745171456,
+      "capacity": "1.02%",
       "total": "376.14 GiB",
       "total_bytes": 403882549248,
-      "used": "3.32 GiB",
-      "used_bytes": 3560300544
+      "used": "3.85 GiB",
+      "used_bytes": 4137377792
     }
   },
+  "memoryfree": "372.29 GiB",
+  "memoryfree_mb": 381226.703125,
+  "memorysize": "376.14 GiB",
+  "memorysize_mb": 385172.4140625,
   "mountpoints": {
     "/": {
-      "available": "35.78 GiB",
-      "available_bytes": 38416805888,
-      "capacity": "8.55%",
+      "available": "35.59 GiB",
+      "available_bytes": 38212149248,
+      "capacity": "9.03%",
       "device": "/dev/sda2",
       "filesystem": "ext4",
       "options": [
@@ -84,8 +122,8 @@
       ],
       "size": "39.12 GiB",
       "size_bytes": 42007232512,
-      "used": "3.34 GiB",
-      "used_bytes": 3590426624
+      "used": "3.53 GiB",
+      "used_bytes": 3795083264
     },
     "/boot": {
       "available": "173.13 MiB",
@@ -188,9 +226,9 @@
       "used_bytes": 16384
     },
     "/run": {
-      "available": "188.03 GiB",
-      "available_bytes": 201896607744,
-      "capacity": "0.02%",
+      "available": "188.02 GiB",
+      "available_bytes": 201888186368,
+      "capacity": "0.03%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
       "options": [
@@ -201,8 +239,8 @@
       ],
       "size": "188.07 GiB",
       "size_bytes": 201941274624,
-      "used": "42.60 MiB",
-      "used_bytes": 44666880
+      "used": "50.63 MiB",
+      "used_bytes": 53088256
     },
     "/run/buse": {
       "available": "0 bytes",
@@ -263,7 +301,7 @@
     },
     "/tmp": {
       "available": "188.07 GiB",
-      "available_bytes": 201940733952,
+      "available_bytes": 201940336640,
       "capacity": "0.00%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -272,8 +310,8 @@
       ],
       "size": "188.07 GiB",
       "size_bytes": 201941274624,
-      "used": "528.00 KiB",
-      "used_bytes": 540672
+      "used": "916.00 KiB",
+      "used_bytes": 937984
     },
     "/var/lib/nfs/rpc_pipefs": {
       "available": "0 bytes",
@@ -289,28 +327,23 @@
       "size_bytes": 0,
       "used": "0 bytes",
       "used_bytes": 0
-    },
-    "/vz/pfcache": {
-      "available": "9.68 GiB",
-      "available_bytes": 10394791936,
-      "capacity": "0.36%",
-      "device": "/dev/ploop16955p1",
-      "filesystem": "ext4",
-      "options": [
-        "rw",
-        "relatime",
-        "stripe=320",
-        "data=ordered",
-        "balloon_ino=12"
-      ],
-      "size": "9.72 GiB",
-      "size_bytes": 10432565248,
-      "used": "36.02 MiB",
-      "used_bytes": 37773312
     }
   },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "192.168.178.0",
+  "network6": "fe80::4ed9:8fff:fe8e:3a5d",
+  "network6_eth0": "fe80::4ed9:8fff:fe8e:3a5d",
+  "network6_lo": "::1",
+  "network_lo": "127.0.0.0",
   "networking": {
-    "dhcp": "10.241.20.10",
+    "dhcp": "169.255.254.1",
     "domain": "example.com",
     "fqdn": "awesome.example.com",
     "hostname": "awesome",
@@ -326,11 +359,16 @@
         "bindings6": [
           {
             "address": "fe80::4ed9:8fff:fe8e:3a5d",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "fe80::4ed9:8fff:fe8e:3a5d"
+          },
+          {
+            "address": "fe80::4ed9:8fff:fe8e:3a5d",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::"
           }
         ],
-        "dhcp": "10.241.20.10",
+        "dhcp": "169.255.254.1",
         "ip": "192.168.178.2",
         "ip6": "fe80::4ed9:8fff:fe8e:3a5d",
         "mac": "4c:d9:8f:8e:3a:5d",
@@ -338,46 +376,7 @@
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
         "network": "192.168.178.0",
-        "network6": "ffff:ffff:ffff:ffff::"
-      },
-      "host-routed": {
-        "mac": "b6:db:45:eb:39:1e",
-        "mtu": 1500
-      },
-      "lo": {
-        "bindings": [
-          {
-            "address": "127.0.0.1",
-            "netmask": "255.0.0.0",
-            "network": "127.0.0.0"
-          }
-        ],
-        "bindings6": [
-          {
-            "address": "::1",
-            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
-            "network": "::1"
-          }
-        ],
-        "ip": "127.0.0.1",
-        "ip6": "::1",
-        "mtu": 65536,
-        "netmask": "255.0.0.0",
-        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
-        "network": "127.0.0.0",
-        "network6": "::1"
-      },
-      "venet0": {
-        "bindings6": [
-          {
-            "address": "fe80::1",
-            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
-            "network": "fe80::1"
-          }
-        ],
-        "ip6": "fe80::1",
-        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
-        "network6": "fe80::1"
+        "network6": "fe80::4ed9:8fff:fe8e:3a5d"
       }
     },
     "ip": "192.168.178.2",
@@ -387,9 +386,12 @@
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
     "network": "192.168.178.0",
-    "network6": "ffff:ffff:ffff:ffff::",
+    "network6": "fe80::4ed9:8fff:fe8e:3a5d",
     "primary": "eth0"
   },
+  "operatingsystem": "VirtuozzoLinux",
+  "operatingsystemmajrelease": "7",
+  "operatingsystemrelease": "7.6",
   "os": {
     "architecture": "x86_64",
     "family": "RedHat",
@@ -404,6 +406,7 @@
       "enabled": false
     }
   },
+  "osfamily": "RedHat",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "ext4",
@@ -411,7 +414,7 @@
       "partuuid": "3ad15c7f-1fa7-4deb-8c41-ccb313ef2046",
       "size": "512.00 MiB",
       "size_bytes": 536870912,
-      "uuid": "7da7d362-2e42-4d14-b87d-484c64577feb"
+      "uuid": "397c61e1-e9fc-4276-b303-76b48e77cd1d"
     },
     "/dev/sda2": {
       "filesystem": "ext4",
@@ -419,7 +422,7 @@
       "partuuid": "50061d33-9672-47a5-ae65-32e8ace5fca1",
       "size": "40.00 GiB",
       "size_bytes": 42949672960,
-      "uuid": "e8b851ad-a5f7-4565-be27-7aed958d36b8"
+      "uuid": "88fd1328-bed0-4a57-b8f1-c0add20d30b9"
     },
     "/dev/sda4": {
       "partuuid": "0b16d042-abb5-4877-9109-8e178c891b78",
@@ -428,8 +431,50 @@
     }
   },
   "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
+  "physicalprocessorcount": 2,
   "primary_ip": "192.168.178.2",
   "primary_mac": "4c:d9:8f:8e:3a:5d",
+  "processor0": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor1": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor10": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor11": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor12": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor13": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor14": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor15": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor16": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor17": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor18": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor19": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor2": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor20": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor21": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor22": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor23": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor24": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor25": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor26": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor27": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor28": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor29": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor3": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor30": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor31": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor32": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor33": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor34": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor35": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor36": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor37": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor38": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor39": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor4": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor5": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor6": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor7": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor8": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processor9": "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40GHz",
+  "processorcount": 40,
   "processors": {
     "count": 40,
     "isa": "x86_64",
@@ -477,43 +522,60 @@
     ],
     "physicalcount": 2
   },
+  "productname": "PowerEdge R440",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
     "version": "2.5.7"
   },
-"ssh": {
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+  "rubyversion": "2.5.7",
+  "selinux": false,
+  "serialnumber": "EHRJIOUE",
+  "ssh": {
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 98d36d25c3eb35a7e4f33c6a315531480c659aa6",
-        "sha256": "SSHFP 3 2 4b2e679cc68a485b9548a23f1f23fd729d9070354d483dfdc0ef912be3e5d976"
+        "sha1": "SSHFP 3 1 3963828ebdd74d96fc943307ea3533942bb484b5",
+        "sha256": "SSHFP 3 2 074830a6c0209eb88b6525bac3c24860f0c2781637c5da8d8f5417a67aba2d29"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAaFtcldMwsHfX80UjirJo9svvtECbCdzP4v3lWvRr7eSesRX8S+MEzyDRA/FkUR8oE881Rvis665jg9iNfnpGk=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFAUsNqKo5e/eNLWmk+LfIA20Jl0lOK/Mtrrgil6ZSWPoaOV0OPldLRfSWiRcQ2AbEXJIMmmx9MQMC8NnE7hGqA=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 f4d461abc7a639d0b4e57fe8f287bad9d5721f9f",
-        "sha256": "SSHFP 4 2 fcbdc4a7be841c769672d425c6d32e9ceeb14c35d301543eb0c48597be074445"
+        "sha1": "SSHFP 4 1 393e359d0a0c5b09ea9b64cc1e05938fc0936ca9",
+        "sha256": "SSHFP 4 2 646703bc4c0db3de3c28a45ef6c0d5c86bd943f40235a19fe8e823e6004c1e85"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIDsnEgMJttiaRIY0pyelkxOqmT/vNOQKmzAeXK/WWGtM",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIC1Oz0nCjBEBiki2xPMm5ZxiRpNRBzhh8qFW+BRTHD5h",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 c08070a9f5157b10ef31d810e9e01df3ef412946",
-        "sha256": "SSHFP 1 2 cfebafe02f968c5b2f46d1b120d2820141f8305746b508637b2596bbb38a6f83"
+        "sha1": "SSHFP 1 1 78e7d5e3edef54e836cd5c7cec4d56f717756bbb",
+        "sha256": "SSHFP 1 2 5043bdffb1387664e7b94d31686428de2ef820237402a036cd7e3daec0896427"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDI12/kfYMzm6g1E1yfVhCTLuRM7QVZEKGvXzlYGtilJXdC6s8VyFsU70vKusLawb/rRfA52hKSUK3mkmQsnkdjt6H/MEaY3qD1uuiGc5XGBACxrZ1LD35Boxmst+LPBT931Q/ml7JmJXNSsSqELKSg5GNvvBX8GLPXwTKOrkNabkVXj8NUtrBXVYjoEo3KyVN0qgQiAFv4UZiFU1AOYKYfpWzMUR2ZQ0dDIuFiceiIae9aWB0S/1o2j9/osFArL1LpL22c3zktT7fGr9pHP5cXgp59TKfQEQ9PqRPYGHXmhkqWKCJ2wvH8n89v2oT3ShP7N47IXdI+wngcDrDylQzB",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC1K2i0KCF24gX+Qq7ftw8wHMbmcyE51bs5L/D4lFehdtUp+j+TYojQh4yjCtp+7z/Vmj9levG7KnqEQs3y+Yz82T+4NbHOqBdFHODuxS+uwHH4Cckux14zLs06wiJzQIp489zrW7nNJffvqeXAfFxMXtyENxMoogf1qEJP2tRsS+13u8PjZkRQQw5+SaupU5yS0YpQ37AO4zY9dx2g/EesmQAAigudFYlHEdPbGdHtoL1S5122rvDVlmLi51N4fERMDEQU0tnQ6bTWNyl/3UYplsZqhLyqwXRs8BF5ceX5drd12NMfvYbsUw3m0cWjb59LeHvVvAgcQ9I4UX6QKx0t",
       "type": "ssh-rsa"
     }
   },
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFAUsNqKo5e/eNLWmk+LfIA20Jl0lOK/Mtrrgil6ZSWPoaOV0OPldLRfSWiRcQ2AbEXJIMmmx9MQMC8NnE7hGqA=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIC1Oz0nCjBEBiki2xPMm5ZxiRpNRBzhh8qFW+BRTHD5h",
+  "sshfp_ecdsa": "SSHFP 3 1 3963828ebdd74d96fc943307ea3533942bb484b5\nSSHFP 3 2 074830a6c0209eb88b6525bac3c24860f0c2781637c5da8d8f5417a67aba2d29",
+  "sshfp_ed25519": "SSHFP 4 1 393e359d0a0c5b09ea9b64cc1e05938fc0936ca9\nSSHFP 4 2 646703bc4c0db3de3c28a45ef6c0d5c86bd943f40235a19fe8e823e6004c1e85",
+  "sshfp_rsa": "SSHFP 1 1 78e7d5e3edef54e836cd5c7cec4d56f717756bbb\nSSHFP 1 2 5043bdffb1387664e7b94d31686428de2ef820237402a036cd7e3daec0896427",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC1K2i0KCF24gX+Qq7ftw8wHMbmcyE51bs5L/D4lFehdtUp+j+TYojQh4yjCtp+7z/Vmj9levG7KnqEQs3y+Yz82T+4NbHOqBdFHODuxS+uwHH4Cckux14zLs06wiJzQIp489zrW7nNJffvqeXAfFxMXtyENxMoogf1qEJP2tRsS+13u8PjZkRQQw5+SaupU5yS0YpQ37AO4zY9dx2g/EesmQAAigudFYlHEdPbGdHtoL1S5122rvDVlmLi51N4fERMDEQU0tnQ6bTWNyl/3UYplsZqhLyqwXRs8BF5ceX5drd12NMfvYbsUw3m0cWjb59LeHvVvAgcQ9I4UX6QKx0t",
   "system_uptime": {
     "days": 1,
-    "hours": 24,
-    "seconds": 88879,
+    "hours": 33,
+    "seconds": 118806,
     "uptime": "1 day"
   },
   "timezone": "UTC",
+  "uptime": "1 day",
+  "uptime_days": 1,
+  "uptime_hours": 33,
+  "uptime_seconds": 118806,
+  "uuid": "4C4C4544-0058-4310-8038-B1C04F525A32",
   "virtual": "openvzhn"
 }

--- a/facts/3.14/archlinux-x86_64.facts
+++ b/facts/3.14/archlinux-x86_64.facts
@@ -1,6 +1,23 @@
 {
+  "architecture": "x86_64",
   "augeas": {
     "version": "1.12.0"
+  },
+  "augeasversion": "1.12.0",
+  "bios_release_date": "12/01/2006",
+  "bios_vendor": "innotek GmbH",
+  "bios_version": "VirtualBox",
+  "blockdevice_sda_model": "VBOX HARDDISK",
+  "blockdevice_sda_size": 21474836480,
+  "blockdevice_sda_vendor": "ATA",
+  "blockdevices": "sda",
+  "boardmanufacturer": "Oracle Corporation",
+  "boardproductname": "VirtualBox",
+  "boardserialnumber": "0",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "eth0": "10.0.2.2",
+    "system": "10.0.2.2"
   },
   "disks": {
     "sda": {
@@ -28,15 +45,21 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "5785c0d5-3d4d-4f95-83ea-93e0ad75833c"
+      "uuid": "eb6e0002-bde8-4896-b25f-780ea4ce4e2d"
     }
   },
-  "facterversion": "3.14.2",
+  "facterversion": "3.14.5",
   "filesystems": "btrfs",
   "fips_enabled": false,
+  "fqdn": "archlinux",
+  "gid": "root",
+  "hardwareisa": "unknown",
+  "hardwaremodel": "x86_64",
+  "hostname": "archlinux",
   "hypervisors": {
     "virtualbox": {}
   },
+  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -44,41 +67,55 @@
     "uid": 0,
     "user": "root"
   },
+  "interfaces": "eth0,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::a00:27ff:feaf:6265",
+  "ipaddress6_eth0": "fe80::a00:27ff:feaf:6265",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
   "kernel": "Linux",
-  "kernelmajversion": "5.2",
-  "kernelrelease": "5.2.13-arch1-1-ARCH",
-  "kernelversion": "5.2.13",
+  "kernelmajversion": "5.3",
+  "kernelrelease": "5.3.1-arch1-1-ARCH",
+  "kernelversion": "5.3.1",
   "load_averages": {
-    "15m": 0.03,
-    "1m": 0.08,
-    "5m": 0.08
+    "15m": 0.25,
+    "1m": 1.07,
+    "5m": 0.57
   },
+  "macaddress": "08:00:27:af:62:65",
+  "macaddress_eth0": "08:00:27:af:62:65",
+  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "1.92 GiB",
-      "available_bytes": 2062544896,
-      "capacity": "0%",
+      "available": "1.91 GiB",
+      "available_bytes": 2055716864,
+      "capacity": "0.13%",
       "total": "1.92 GiB",
-      "total_bytes": 2062544896,
-      "used": "0 bytes",
-      "used_bytes": 0
+      "total_bytes": 2058350592,
+      "used": "2.51 MiB",
+      "used_bytes": 2633728
     },
     "system": {
-      "available": "822.27 MiB",
-      "available_bytes": 862208000,
-      "capacity": "16.49%",
-      "total": "984.58 MiB",
-      "total_bytes": 1032404992,
-      "used": "162.31 MiB",
-      "used_bytes": 170196992
+      "available": "797.25 MiB",
+      "available_bytes": 835977216,
+      "capacity": "18.90%",
+      "total": "983.05 MiB",
+      "total_bytes": 1030807552,
+      "used": "185.80 MiB",
+      "used_bytes": 194830336
     }
   },
+  "memoryfree": "797.25 MiB",
+  "memoryfree_mb": 797.25,
+  "memorysize": "983.05 MiB",
+  "memorysize_mb": 983.0546875,
   "mountpoints": {
     "/": {
-      "available": "16.60 GiB",
-      "available_bytes": 17825533952,
-      "capacity": "8.17%",
+      "available": "16.02 GiB",
+      "available_bytes": 17204256768,
+      "capacity": "11.39%",
       "device": "/dev/sda2",
       "filesystem": "btrfs",
       "options": [
@@ -89,13 +126,13 @@
         "subvol=/"
       ],
       "size": "18.08 GiB",
-      "size_bytes": 19411238912,
-      "used": "1.48 GiB",
-      "used_bytes": 1585704960
+      "size_bytes": 19415433216,
+      "used": "2.06 GiB",
+      "used_bytes": 2211176448
     },
     "/dev": {
-      "available": "485.05 MiB",
-      "available_bytes": 508616704,
+      "available": "484.30 MiB",
+      "available_bytes": 507826176,
       "capacity": "0%",
       "device": "dev",
       "filesystem": "devtmpfs",
@@ -103,12 +140,12 @@
         "rw",
         "nosuid",
         "relatime",
-        "size=496696k",
-        "nr_inodes=124174",
+        "size=495924k",
+        "nr_inodes=123981",
         "mode=755"
       ],
-      "size": "485.05 MiB",
-      "size_bytes": 508616704,
+      "size": "484.30 MiB",
+      "size_bytes": 507826176,
       "used": "0 bytes",
       "used_bytes": 0
     },
@@ -167,8 +204,8 @@
       "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "492.29 MiB",
-      "available_bytes": 516202496,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -177,14 +214,14 @@
         "nosuid",
         "nodev"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/run": {
-      "available": "491.90 MiB",
-      "available_bytes": 515796992,
+      "available": "491.14 MiB",
+      "available_bytes": 514994176,
       "capacity": "0.08%",
       "device": "run",
       "filesystem": "tmpfs",
@@ -195,14 +232,14 @@
         "relatime",
         "mode=755"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
-      "used": "396.00 KiB",
-      "used_bytes": 405504
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
+      "used": "400.00 KiB",
+      "used_bytes": 409600
     },
     "/run/user/1000": {
-      "available": "98.46 MiB",
-      "available_bytes": 103239680,
+      "available": "98.30 MiB",
+      "available_bytes": 103079936,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -211,19 +248,19 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=100820k",
+        "size=100664k",
         "mode=700",
         "uid=1000",
         "gid=1000"
       ],
-      "size": "98.46 MiB",
-      "size_bytes": 103239680,
+      "size": "98.30 MiB",
+      "size_bytes": 103079936,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/sys/fs/cgroup": {
-      "available": "492.29 MiB",
-      "available_bytes": 516202496,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -234,14 +271,14 @@
         "noexec",
         "mode=755"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/tmp": {
-      "available": "492.29 MiB",
-      "available_bytes": 516202496,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -250,15 +287,15 @@
         "nosuid",
         "nodev"
       ],
-      "size": "492.29 MiB",
-      "size_bytes": 516202496,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/vagrant": {
-      "available": "7.77 GiB",
-      "available_bytes": 8340070400,
-      "capacity": "96.67%",
+      "available": "28.43 GiB",
+      "available_bytes": 30522138624,
+      "capacity": "87.81%",
       "device": "vagrant",
       "filesystem": "vboxsf",
       "options": [
@@ -267,10 +304,24 @@
       ],
       "size": "233.10 GiB",
       "size_bytes": 250293325824,
-      "used": "225.34 GiB",
-      "used_bytes": 241953255424
+      "used": "204.68 GiB",
+      "used_bytes": 219771187200
     }
   },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_eth0": "fe80::",
+  "network6_lo": "::1",
+  "network_eth0": "10.0.2.0",
+  "network_lo": "127.0.0.0",
   "networking": {
     "dhcp": "10.0.2.2",
     "fqdn": "archlinux",
@@ -286,15 +337,15 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:fe68:5327",
+            "address": "fe80::a00:27ff:feaf:6265",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::"
           }
         ],
         "dhcp": "10.0.2.2",
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:fe68:5327",
-        "mac": "08:00:27:68:53:27",
+        "ip6": "fe80::a00:27ff:feaf:6265",
+        "mac": "08:00:27:af:62:65",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -326,8 +377,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:fe68:5327",
-    "mac": "08:00:27:68:53:27",
+    "ip6": "fe80::a00:27ff:feaf:6265",
+    "mac": "08:00:27:af:62:65",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -335,39 +386,47 @@
     "network6": "fe80::",
     "primary": "eth0"
   },
+  "operatingsystem": "Archlinux",
+  "operatingsystemmajrelease": "5",
+  "operatingsystemrelease": "5.3.1-arch1-1-ARCH",
   "os": {
     "architecture": "x86_64",
     "family": "Archlinux",
     "hardware": "x86_64",
     "name": "Archlinux",
     "release": {
-      "full": "5.2.13-arch1-1-ARCH",
+      "full": "5.3.1-arch1-1-ARCH",
       "major": "5",
-      "minor": "2"
+      "minor": "3"
     },
     "selinux": {
       "enabled": false
     }
   },
+  "osfamily": "Archlinux",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
-      "partuuid": "a0254c1f-01",
+      "partuuid": "2838d854-01",
       "size": "1.92 GiB",
-      "size_bytes": 2062548992,
-      "uuid": "4ff94364-bf85-4419-8deb-f64d6bdb6696"
+      "size_bytes": 2058354688,
+      "uuid": "eba0ebc5-1db1-4b9c-9b6a-8939751900b2"
     },
     "/dev/sda2": {
       "filesystem": "btrfs",
       "label": "rootfs",
       "mount": "/",
-      "partuuid": "a0254c1f-02",
+      "partuuid": "2838d854-02",
       "size": "18.08 GiB",
-      "size_bytes": 19411238912,
-      "uuid": "f859381e-3d54-4c8e-8a55-8b3702de6b9c"
+      "size_bytes": 19415433216,
+      "uuid": "dee4d316-8cf6-45ce-9182-293d7e7c9103"
     }
   },
-  "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/sbin:/sbin",
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/sbin:/sbin",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+  "processor1": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "unknown",
@@ -377,52 +436,75 @@
     ],
     "physicalcount": 1
   },
+  "productname": "VirtualBox",
   "puppetversion": "6.8.1",
   "ruby": {
     "platform": "x86_64-linux",
     "sitedir": "/usr/lib/ruby/site_ruby/2.6.0",
-    "version": "2.6.4"
+    "version": "2.6.5"
   },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/usr/lib/ruby/site_ruby/2.6.0",
+  "rubyversion": "2.6.5",
+  "selinux": false,
+  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
-        "sha1": "SSHFP 2 1 04e7b6517e9f124486b8b0fc6528aab57c1bc547",
-        "sha256": "SSHFP 2 2 67dbb5f91964b624c06b46bff850e76a42a57dd91cc22a51d44e67f82c5721df"
+        "sha1": "SSHFP 2 1 a0c65effb04d04954bb4d09d53db282f9aca790d",
+        "sha256": "SSHFP 2 2 fd47b56f405a89f9e941d15a1559742389759aad6ea1ab6d965a806efda77b04"
       },
-      "key": "AAAAB3NzaC1kc3MAAACBAMNGIMeVYPwx37+qiZpPxhOB2ss8FEakiNqejneuWW+iria8aLlch1V+2z/gdgePTI6dlPSWMMiCdvLhYZfr9PW5BQ8vZOEdUnlvgb202EmkbP46tnBhIBHV/Qq10rA95yHu/XBsMzLJZtb0UleCCel66aOU6GCsi3jDCHRGWC1dAAAAFQDI2saHjGyWW6GPOvCOsnIX+uuJOQAAAIAfCWY46ehwQzqthU25tFkW8HepxOCgntDBten630VQGD9l2hrFnLf6DfkvCoaqgTtdeZE5nehUoQ6DobivtpAaOx+SdPJi3HaKZz3WwFJ+kOOlj4cqQVHpU5fAlQ8fLlBGsZ8iT8bRLAfWDvqbDWkRkUGCCSFR6bglD8+gVB1UnQAAAIB+CsJGiMJoIysi0nZ1tGJg16hbe5s0hgqQI5AFtRGFzw2X5opagDeXtdFLAIwoOMUTO0J1TWD1lT0DymxYFFMQ/hk0YcuKQnGMJwPE1CUpH9SzJY8rOa9LXfquRoTDoXfeEu3XiHVKuLCoyouPRAy/kOKQCDpS8nLuVLTNkiOxfw==",
+      "key": "AAAAB3NzaC1kc3MAAACBAPiwPPwnebfeoRN1I8OnPYy4HpUZcbWBOY04iwPc2cZuFtkCvuw+gJPkeY6YxeZdNH5kTkZxqWPv2hs8SHWoh4CD+GeG0yfFmKbPYOCCyeU6nmm99SDuFP6R0Ogbx4fsqTkTBFCOZBlRizf+XNCIvIXsY0wu1AaN/1nuw92ukXqBAAAAFQD0Yt4V24h7HTR+sVh+yQPI5H+TawAAAIAb90fPshJB1cOggwklhtfD8lmXpif5k007asLNqsN0ai7vJue3cxxizmXZ5kt6/tYtnFUwW/E7kp7A4Fy0P3uxoFx5QxIBjaBEh0QPlGPvGOJ/L9uH727hVG557Xv4ScKGqOLVK1quYMxkItRwK3xMewGDIrpbvXyCRvXxZgcwswAAAIEA8xikmNqoSMPzS/9uGlDhMoChcqACaALJn+cWRrf3chMc3ox3LH8W6w5koXofXUpN/S481l3hszoNMuX8JRKROWoBBkYaohOtSvuDzJz7Sku3owNKIEvPecFffYQ6CcbPLc0Z0zPQshFo9ny+A2V040JTQxlF+iv1B49CB43xjBs=",
       "type": "ssh-dss"
     },
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 76a64f6b3a843297d10d1397266ca81b5e8b62f7",
-        "sha256": "SSHFP 3 2 15977bc2b7967c141a4b33736aada7798acc97bd06ef871f91c5cadc424bd376"
+        "sha1": "SSHFP 3 1 ea6f05fde6d599793074cc4de596bae3d516b2ed",
+        "sha256": "SSHFP 3 2 77bf426f6a78918845431402dc249f12b80a5d3aa7326564f61c16d9712f180b"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBP9U5gopmw5oeYoXoX4ewE0DH5XbyYs3HLSZgb+CLmzEfCxYRZivMssgsHNKuB3bbo3gw/B8/zSooCDCn4pTaCA=",
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDfkrDP0uirsivVd1pib+bOL62pluqaXKV3aEs/hVCU3zvar5NILZJXnTBynsUZ8TPCyjKpS0dEW6PlJaoeQGuI=",
       "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 5b470e14ec0b17f5b00f36e92032cf8c51d0bfa1",
-        "sha256": "SSHFP 4 2 60f07c5408828bfe20d102cf8a73c977ad11e22977314588353b8e3b520d1bea"
+        "sha1": "SSHFP 4 1 7038e89f3142c34fbaf0b3e86c430662777cb8f8",
+        "sha256": "SSHFP 4 2 9149930a442825395673739a8d1bea14cd7cf0c89c72908c4ef6c67a2557dc59"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIP4jSdQBYtq1ERK8oQa04myrpUF83VyJxAfFCyno1KLi",
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIOGmEoGAMVm3P264nKeiz37e/cT1NXlrVvN/+k0XT/ls",
       "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 d1e282567af2608401de29f60197298a8edb617a",
-        "sha256": "SSHFP 1 2 4b6596c1f712bcff21e81147c32d26f4db0428d8562f3328117643fe3e3a1d27"
+        "sha1": "SSHFP 1 1 b836981a1d246e48cd5577e257545ac8ef9c63c3",
+        "sha256": "SSHFP 1 2 d59cdbfccdcde30f959a1dc6195d5e54ab76802800c9fcef6c748ca697735708"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDNRNf7Y8L8GgUzO5EL1ybU7gk/DTOX0F0jW+d4LU8JN5shOjaw2hNdk3Ft78VqgRNDXp5QOCD3XM5DTs/mwabAbvN2G0xc2VY30mW+FQgOxzbw7xGPyX6mtBtxukH2r5bsiEVDl5c3lpMY9AuQJnMRdnTXjeUzX4RQHAQ6TfKI/mDAcjFjNgh69dgOIaz4HcgCJbks4FxRhCCfWtYC9z/+AfSz+yeaef84LdEysJhJ6sQPhTbkEvzvR9WU2UmnctZZS3qZkFrS4ypEVI/q2inFWHHMScHRbaY4LNr5EUIpSb9SO2LwGUN9CxHDsCdnIQr2lqunwfNVdcxJ3HiA4ziadAr0TGb8ryx5MpgioLxkp/hSPqWkuKSQEUYO8mnxlHhZRFhUq5X3ST4OQ4kMERKoY8xfMKAfEpKrpi9+prGAJSy064aUTRk6UQ6i2XhuasgLF9gbN57Sn5PDivERLpQQXO9DcfB2Q7dMmPPT38XwKkXe3kjeI0EftH4GxX7xoHc=",
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDOZqEYyOU8hXsx0Y/74wkY67LYJfsr9mhgX2B7moQKCinCL9e2jvwhXYNo1dF+mAp2qNa9K96YEG9G6U/Xaf/pCmQ3c0q+omDeInMzLr9mmgH7SZLdTr4NlyTl3sDZvpKepN9+CUxyf5gVYXvAFoFiIecxXC96d2oqvta/ljnJh26tMGfBL3Il8kTxqwMwaImSalLgi9239W+SM4yuk+10QAzpNhr1JlrhWeVHttxQbifx4oRBf88wrZlYBNp1QcPoQbcuFPuJXoPC3J94QmhL7Mh+K2j/IOZf/hZ/ZjYdQwFXPoYellMJwPQy6FjP/ht139MNL7uB53evw6BGwX0e/8dWS1FqToK4djF8ci2LQ03XXXKK6vVy8ypWwHWGNXSd9sehwyfHF0Xylx+4xnWJ1ySoYIHCUiOiusklYFvZC+sgKUK/VFN/q7S98oZDlkwAhNuUrR5gw2uThA83U0rEDqvTavgMWsEycQ0fEi0SNWG40fqrVVPjIx2CYYBeQkU=",
       "type": "ssh-rsa"
     }
   },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBAPiwPPwnebfeoRN1I8OnPYy4HpUZcbWBOY04iwPc2cZuFtkCvuw+gJPkeY6YxeZdNH5kTkZxqWPv2hs8SHWoh4CD+GeG0yfFmKbPYOCCyeU6nmm99SDuFP6R0Ogbx4fsqTkTBFCOZBlRizf+XNCIvIXsY0wu1AaN/1nuw92ukXqBAAAAFQD0Yt4V24h7HTR+sVh+yQPI5H+TawAAAIAb90fPshJB1cOggwklhtfD8lmXpif5k007asLNqsN0ai7vJue3cxxizmXZ5kt6/tYtnFUwW/E7kp7A4Fy0P3uxoFx5QxIBjaBEh0QPlGPvGOJ/L9uH727hVG557Xv4ScKGqOLVK1quYMxkItRwK3xMewGDIrpbvXyCRvXxZgcwswAAAIEA8xikmNqoSMPzS/9uGlDhMoChcqACaALJn+cWRrf3chMc3ox3LH8W6w5koXofXUpN/S481l3hszoNMuX8JRKROWoBBkYaohOtSvuDzJz7Sku3owNKIEvPecFffYQ6CcbPLc0Z0zPQshFo9ny+A2V040JTQxlF+iv1B49CB43xjBs=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDfkrDP0uirsivVd1pib+bOL62pluqaXKV3aEs/hVCU3zvar5NILZJXnTBynsUZ8TPCyjKpS0dEW6PlJaoeQGuI=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIOGmEoGAMVm3P264nKeiz37e/cT1NXlrVvN/+k0XT/ls",
+  "sshfp_dsa": "SSHFP 2 1 a0c65effb04d04954bb4d09d53db282f9aca790d\nSSHFP 2 2 fd47b56f405a89f9e941d15a1559742389759aad6ea1ab6d965a806efda77b04",
+  "sshfp_ecdsa": "SSHFP 3 1 ea6f05fde6d599793074cc4de596bae3d516b2ed\nSSHFP 3 2 77bf426f6a78918845431402dc249f12b80a5d3aa7326564f61c16d9712f180b",
+  "sshfp_ed25519": "SSHFP 4 1 7038e89f3142c34fbaf0b3e86c430662777cb8f8\nSSHFP 4 2 9149930a442825395673739a8d1bea14cd7cf0c89c72908c4ef6c67a2557dc59",
+  "sshfp_rsa": "SSHFP 1 1 b836981a1d246e48cd5577e257545ac8ef9c63c3\nSSHFP 1 2 d59cdbfccdcde30f959a1dc6195d5e54ab76802800c9fcef6c748ca697735708",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDOZqEYyOU8hXsx0Y/74wkY67LYJfsr9mhgX2B7moQKCinCL9e2jvwhXYNo1dF+mAp2qNa9K96YEG9G6U/Xaf/pCmQ3c0q+omDeInMzLr9mmgH7SZLdTr4NlyTl3sDZvpKepN9+CUxyf5gVYXvAFoFiIecxXC96d2oqvta/ljnJh26tMGfBL3Il8kTxqwMwaImSalLgi9239W+SM4yuk+10QAzpNhr1JlrhWeVHttxQbifx4oRBf88wrZlYBNp1QcPoQbcuFPuJXoPC3J94QmhL7Mh+K2j/IOZf/hZ/ZjYdQwFXPoYellMJwPQy6FjP/ht139MNL7uB53evw6BGwX0e/8dWS1FqToK4djF8ci2LQ03XXXKK6vVy8ypWwHWGNXSd9sehwyfHF0Xylx+4xnWJ1ySoYIHCUiOiusklYFvZC+sgKUK/VFN/q7S98oZDlkwAhNuUrR5gw2uThA83U0rEDqvTavgMWsEycQ0fEi0SNWG40fqrVVPjIx2CYYBeQkU=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1960.484375,
+  "swapsize": "1.92 GiB",
+  "swapsize_mb": 1962.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 264,
+    "seconds": 268,
     "uptime": "0:04 hours"
   },
   "timezone": "UTC",
+  "uptime": "0:04 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 268,
+  "uuid": "eb6e0002-bde8-4896-b25f-780ea4ce4e2d",
   "virtual": "virtualbox"
 }

--- a/facts/3.9/archlinux-x86_64.facts
+++ b/facts/3.9/archlinux-x86_64.facts
@@ -1,4 +1,24 @@
 {
+  "architecture": "x86_64",
+  "augeas": {
+    "version": "1.12.0"
+  },
+  "augeasversion": "1.12.0",
+  "bios_release_date": "12/01/2006",
+  "bios_vendor": "innotek GmbH",
+  "bios_version": "VirtualBox",
+  "blockdevice_sda_model": "VBOX HARDDISK",
+  "blockdevice_sda_size": 21474836480,
+  "blockdevice_sda_vendor": "ATA",
+  "blockdevices": "sda",
+  "boardmanufacturer": "Oracle Corporation",
+  "boardproductname": "VirtualBox",
+  "boardserialnumber": "0",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "eth0": "10.0.2.2",
+    "system": "10.0.2.2"
+  },
   "disks": {
     "sda": {
       "model": "VBOX HARDDISK",
@@ -25,11 +45,21 @@
     "product": {
       "name": "VirtualBox",
       "serial_number": "0",
-      "uuid": "5E735075-6745-4A26-9737-98C0125A7CE6"
+      "uuid": "eb6e0002-bde8-4896-b25f-780ea4ce4e2d"
     }
   },
   "facterversion": "3.9.5",
   "filesystems": "btrfs",
+  "fips_enabled": false,
+  "fqdn": "archlinux",
+  "gid": "root",
+  "hardwareisa": "unknown",
+  "hardwaremodel": "x86_64",
+  "hostname": "archlinux",
+  "hypervisors": {
+    "virtualbox": {}
+  },
+  "id": "root",
   "identity": {
     "gid": 0,
     "group": "root",
@@ -37,41 +67,55 @@
     "uid": 0,
     "user": "root"
   },
+  "interfaces": "eth0,lo",
+  "ipaddress": "10.0.2.15",
+  "ipaddress6": "fe80::a00:27ff:feaf:6265",
+  "ipaddress6_eth0": "fe80::a00:27ff:feaf:6265",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "10.0.2.15",
+  "ipaddress_lo": "127.0.0.1",
   "is_virtual": true,
   "kernel": "Linux",
-  "kernelmajversion": "4.15",
-  "kernelrelease": "4.15.6-1-ARCH",
-  "kernelversion": "4.15.6",
+  "kernelmajversion": "5.3",
+  "kernelrelease": "5.3.1-arch1-1-ARCH",
+  "kernelversion": "5.3.1",
   "load_averages": {
-    "15m": 0.0,
-    "1m": 0.0,
-    "5m": 0.0
+    "15m": 0.25,
+    "1m": 1.07,
+    "5m": 0.57
   },
+  "macaddress": "08:00:27:af:62:65",
+  "macaddress_eth0": "08:00:27:af:62:65",
+  "manufacturer": "innotek GmbH",
   "memory": {
     "swap": {
-      "available": "1.93 GiB",
-      "available_bytes": 2075127808,
-      "capacity": "0%",
-      "total": "1.93 GiB",
-      "total_bytes": 2075127808,
-      "used": "0 bytes",
-      "used_bytes": 0
+      "available": "1.91 GiB",
+      "available_bytes": 2055716864,
+      "capacity": "0.13%",
+      "total": "1.92 GiB",
+      "total_bytes": 2058350592,
+      "used": "2.51 MiB",
+      "used_bytes": 2633728
     },
     "system": {
-      "available": "923.61 MiB",
-      "available_bytes": 968474624,
-      "capacity": "6.61%",
-      "total": "989.00 MiB",
-      "total_bytes": 1037041664,
-      "used": "65.39 MiB",
-      "used_bytes": 68567040
+      "available": "797.25 MiB",
+      "available_bytes": 835977216,
+      "capacity": "18.90%",
+      "total": "983.05 MiB",
+      "total_bytes": 1030807552,
+      "used": "185.80 MiB",
+      "used_bytes": 194830336
     }
   },
+  "memoryfree": "797.25 MiB",
+  "memoryfree_mb": 797.25,
+  "memorysize": "983.05 MiB",
+  "memorysize_mb": 983.0546875,
   "mountpoints": {
     "/": {
-      "available": "16.81 GiB",
-      "available_bytes": 18053324800,
-      "capacity": "6.94%",
+      "available": "16.02 GiB",
+      "available_bytes": 17204256768,
+      "capacity": "11.39%",
       "device": "/dev/sda2",
       "filesystem": "btrfs",
       "options": [
@@ -81,14 +125,87 @@
         "subvolid=5",
         "subvol=/"
       ],
-      "size": "18.07 GiB",
-      "size_bytes": 19398656000,
-      "used": "1.25 GiB",
-      "used_bytes": 1345331200
+      "size": "18.08 GiB",
+      "size_bytes": 19415433216,
+      "used": "2.06 GiB",
+      "used_bytes": 2211176448
+    },
+    "/dev": {
+      "available": "484.30 MiB",
+      "available_bytes": 507826176,
+      "capacity": "0%",
+      "device": "dev",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "nosuid",
+        "relatime",
+        "size=495924k",
+        "nr_inodes=123981",
+        "mode=755"
+      ],
+      "size": "484.30 MiB",
+      "size_bytes": 507826176,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "relatime",
+        "pagesize=2M"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
     },
     "/dev/shm": {
-      "available": "494.50 MiB",
-      "available_bytes": 518520832,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -97,15 +214,15 @@
         "nosuid",
         "nodev"
       ],
-      "size": "494.50 MiB",
-      "size_bytes": 518520832,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/run": {
-      "available": "494.14 MiB",
-      "available_bytes": 518139904,
-      "capacity": "0.07%",
+      "available": "491.14 MiB",
+      "available_bytes": 514994176,
+      "capacity": "0.08%",
       "device": "run",
       "filesystem": "tmpfs",
       "options": [
@@ -115,14 +232,14 @@
         "relatime",
         "mode=755"
       ],
-      "size": "494.50 MiB",
-      "size_bytes": 518520832,
-      "used": "372.00 KiB",
-      "used_bytes": 380928
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
+      "used": "400.00 KiB",
+      "used_bytes": 409600
     },
     "/run/user/1000": {
-      "available": "98.90 MiB",
-      "available_bytes": 103702528,
+      "available": "98.30 MiB",
+      "available_bytes": 103079936,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -131,19 +248,19 @@
         "nosuid",
         "nodev",
         "relatime",
-        "size=101272k",
+        "size=100664k",
         "mode=700",
         "uid=1000",
         "gid=1000"
       ],
-      "size": "98.90 MiB",
-      "size_bytes": 103702528,
+      "size": "98.30 MiB",
+      "size_bytes": 103079936,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/sys/fs/cgroup": {
-      "available": "494.50 MiB",
-      "available_bytes": 518520832,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -154,14 +271,14 @@
         "noexec",
         "mode=755"
       ],
-      "size": "494.50 MiB",
-      "size_bytes": 518520832,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
     },
     "/tmp": {
-      "available": "494.50 MiB",
-      "available_bytes": 518520832,
+      "available": "491.53 MiB",
+      "available_bytes": 515403776,
       "capacity": "0%",
       "device": "tmpfs",
       "filesystem": "tmpfs",
@@ -170,16 +287,45 @@
         "nosuid",
         "nodev"
       ],
-      "size": "494.50 MiB",
-      "size_bytes": 518520832,
+      "size": "491.53 MiB",
+      "size_bytes": 515403776,
       "used": "0 bytes",
       "used_bytes": 0
+    },
+    "/vagrant": {
+      "available": "28.43 GiB",
+      "available_bytes": 30522138624,
+      "capacity": "87.81%",
+      "device": "vagrant",
+      "filesystem": "vboxsf",
+      "options": [
+        "rw",
+        "relatime"
+      ],
+      "size": "233.10 GiB",
+      "size_bytes": 250293325824,
+      "used": "204.68 GiB",
+      "used_bytes": 219771187200
     }
   },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "10.0.2.0",
+  "network6": "fe80::",
+  "network6_eth0": "fe80::",
+  "network6_lo": "::1",
+  "network_eth0": "10.0.2.0",
+  "network_lo": "127.0.0.0",
   "networking": {
-    "domain": "example.com",
-    "fqdn": "foo.example.com",
-    "hostname": "foo",
+    "dhcp": "10.0.2.2",
+    "fqdn": "archlinux",
+    "hostname": "archlinux",
     "interfaces": {
       "eth0": {
         "bindings": [
@@ -191,14 +337,15 @@
         ],
         "bindings6": [
           {
-            "address": "fe80::a00:27ff:feb0:7f01",
+            "address": "fe80::a00:27ff:feaf:6265",
             "netmask": "ffff:ffff:ffff:ffff::",
             "network": "fe80::"
           }
         ],
+        "dhcp": "10.0.2.2",
         "ip": "10.0.2.15",
-        "ip6": "fe80::a00:27ff:feb0:7f01",
-        "mac": "08:00:27:b0:7f:01",
+        "ip6": "fe80::a00:27ff:feaf:6265",
+        "mac": "08:00:27:af:62:65",
         "mtu": 1500,
         "netmask": "255.255.255.0",
         "netmask6": "ffff:ffff:ffff:ffff::",
@@ -230,8 +377,8 @@
       }
     },
     "ip": "10.0.2.15",
-    "ip6": "fe80::a00:27ff:feb0:7f01",
-    "mac": "08:00:27:b0:7f:01",
+    "ip6": "fe80::a00:27ff:feaf:6265",
+    "mac": "08:00:27:af:62:65",
     "mtu": 1500,
     "netmask": "255.255.255.0",
     "netmask6": "ffff:ffff:ffff:ffff::",
@@ -239,89 +386,125 @@
     "network6": "fe80::",
     "primary": "eth0"
   },
+  "operatingsystem": "Archlinux",
+  "operatingsystemmajrelease": "5",
+  "operatingsystemrelease": "5.3.1-arch1-1-ARCH",
   "os": {
     "architecture": "x86_64",
     "family": "Archlinux",
     "hardware": "x86_64",
     "name": "Archlinux",
     "release": {
-      "full": "4.15.6-1-ARCH",
-      "major": "4",
-      "minor": "15"
+      "full": "5.3.1-arch1-1-ARCH",
+      "major": "5",
+      "minor": "3"
     },
     "selinux": {
       "enabled": false
     }
   },
+  "osfamily": "Archlinux",
   "partitions": {
     "/dev/sda1": {
       "filesystem": "swap",
-      "partuuid": "aa522480-01",
-      "size": "1.93 GiB",
-      "size_bytes": 2075131904,
-      "uuid": "cd51174e-596f-4546-9da6-5ca42e091e9c"
+      "partuuid": "2838d854-01",
+      "size": "1.92 GiB",
+      "size_bytes": 2058354688,
+      "uuid": "eba0ebc5-1db1-4b9c-9b6a-8939751900b2"
     },
     "/dev/sda2": {
       "filesystem": "btrfs",
       "label": "rootfs",
       "mount": "/",
-      "partuuid": "aa522480-02",
-      "size": "18.07 GiB",
-      "size_bytes": 19398656000,
-      "uuid": "2a17b9f3-baab-4863-9a62-1fbda239540b"
+      "partuuid": "2838d854-02",
+      "size": "18.08 GiB",
+      "size_bytes": 19415433216,
+      "uuid": "dee4d316-8cf6-45ce-9182-293d7e7c9103"
     }
   },
-  "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl",
+  "path": "/opt/puppetlabs/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/sbin:/sbin",
+  "physicalprocessorcount": 1,
+  "processor0": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+  "processor1": "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+  "processorcount": 2,
   "processors": {
     "count": 2,
     "isa": "unknown",
     "models": [
-      "Intel(R) Core(TM) i5-2500K CPU @ 3.30GHz",
-      "Intel(R) Core(TM) i5-2500K CPU @ 3.30GHz"
+      "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz",
+      "Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz"
     ],
     "physicalcount": 1
   },
+  "productname": "VirtualBox",
+  "puppetversion": "6.8.1",
   "ruby": {
     "platform": "x86_64-linux",
-    "sitedir": "/usr/lib/ruby/site_ruby/2.5.0",
-    "version": "2.5.0"
+    "sitedir": "/usr/lib/ruby/site_ruby/2.6.0",
+    "version": "2.6.5"
   },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/usr/lib/ruby/site_ruby/2.6.0",
+  "rubyversion": "2.6.5",
+  "selinux": false,
+  "serialnumber": "0",
   "ssh": {
     "dsa": {
       "fingerprints": {
-        "sha1": "SSHFP 2 1 011adbe28fec0c1d040bbba0ebc402672f8f35cc",
-        "sha256": "SSHFP 2 2 7180c131b6933346119a2bb64b62ad79309d14b281863cf33d46472940d2bf73"
+        "sha1": "SSHFP 2 1 a0c65effb04d04954bb4d09d53db282f9aca790d",
+        "sha256": "SSHFP 2 2 fd47b56f405a89f9e941d15a1559742389759aad6ea1ab6d965a806efda77b04"
       },
-      "key": "AAAAB3NzaC1kc3MAAACBAOoIb51xP6m2P9LMF8aniIfPCxV5g+uDQ6G8AGIUdd9/f4AxkX1qVAW+abqALgK7WU5k4aV6xGLsuLtvF0r6iM3TWHe66Q6WAjU4jZPUFWQydKHXfp2Z28TUYpmVkBTGeCsrlg1wpaBH0pC4ZVgVJk9pYFDh+DweJBiORyjq76D7AAAAFQCVHWHYlvPRvxbhN7Xzr2ZYLzLkuwAAAIEA2O1JAhqD5ANa9ThM9xicJj4ScYaKKk4QF2KP+jffo/K+FOcphAfB21ORgeE8271HTzosP64SLVot8K/fBtkdopknKLEPLAw5l4oaYIaYqhpzr4iQ8OXL9LkAp+1TxLOO6kprcrgGaLNRR6/Fejj76Fvf5wqRo9qCcnkZ6ZOid0EAAACAJh8lpOAgZsWQQAw2LDqlLcojc0BbqjPX+i5D2UN69dk01KGNpCNDE+9HNLt2M+VfFyMWiVNKAj4D+E0QFB2Ql+TEFhLtW6IobfClHsOOF6UbuQrwKzTuo6ndcSa6ofdlEBjorAqUxWtfNSmU7MboWYteXhUXsDgjooME8zD2ZUI="
+      "key": "AAAAB3NzaC1kc3MAAACBAPiwPPwnebfeoRN1I8OnPYy4HpUZcbWBOY04iwPc2cZuFtkCvuw+gJPkeY6YxeZdNH5kTkZxqWPv2hs8SHWoh4CD+GeG0yfFmKbPYOCCyeU6nmm99SDuFP6R0Ogbx4fsqTkTBFCOZBlRizf+XNCIvIXsY0wu1AaN/1nuw92ukXqBAAAAFQD0Yt4V24h7HTR+sVh+yQPI5H+TawAAAIAb90fPshJB1cOggwklhtfD8lmXpif5k007asLNqsN0ai7vJue3cxxizmXZ5kt6/tYtnFUwW/E7kp7A4Fy0P3uxoFx5QxIBjaBEh0QPlGPvGOJ/L9uH727hVG557Xv4ScKGqOLVK1quYMxkItRwK3xMewGDIrpbvXyCRvXxZgcwswAAAIEA8xikmNqoSMPzS/9uGlDhMoChcqACaALJn+cWRrf3chMc3ox3LH8W6w5koXofXUpN/S481l3hszoNMuX8JRKROWoBBkYaohOtSvuDzJz7Sku3owNKIEvPecFffYQ6CcbPLc0Z0zPQshFo9ny+A2V040JTQxlF+iv1B49CB43xjBs=",
+      "type": "ssh-dss"
     },
     "ecdsa": {
       "fingerprints": {
-        "sha1": "SSHFP 3 1 5a1a437277b6d03c25651e71c5d07f5a8fdcffcb",
-        "sha256": "SSHFP 3 2 6cbf066f80b03298945731531372cb044578186b5ff24c307b4f338676699991"
+        "sha1": "SSHFP 3 1 ea6f05fde6d599793074cc4de596bae3d516b2ed",
+        "sha256": "SSHFP 3 2 77bf426f6a78918845431402dc249f12b80a5d3aa7326564f61c16d9712f180b"
       },
-      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCBvGLAS1iyk9i+dajFcFEzzZtRRyQlF+LirsQU8QGEtq0opy62VTmakc/cRHhhGJMr9dRBbLJ2xv3Z4w/Tfi5k="
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDfkrDP0uirsivVd1pib+bOL62pluqaXKV3aEs/hVCU3zvar5NILZJXnTBynsUZ8TPCyjKpS0dEW6PlJaoeQGuI=",
+      "type": "ecdsa-sha2-nistp256"
     },
     "ed25519": {
       "fingerprints": {
-        "sha1": "SSHFP 4 1 62a6a49153e15d2eba583604ee80a86185b6a5bb",
-        "sha256": "SSHFP 4 2 82ac7cb51493c122863a1f273a422ea1742ddfd4ffd88a4531d45bd2d546c363"
+        "sha1": "SSHFP 4 1 7038e89f3142c34fbaf0b3e86c430662777cb8f8",
+        "sha256": "SSHFP 4 2 9149930a442825395673739a8d1bea14cd7cf0c89c72908c4ef6c67a2557dc59"
       },
-      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIDP6MHyWDm0QVqEJExFBt/8edtzSlzE9BS2OlQTyhqQR"
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIOGmEoGAMVm3P264nKeiz37e/cT1NXlrVvN/+k0XT/ls",
+      "type": "ssh-ed25519"
     },
     "rsa": {
       "fingerprints": {
-        "sha1": "SSHFP 1 1 32f42ae009bcbf9b6182305a153f9f4f912e829a",
-        "sha256": "SSHFP 1 2 0a50ce99556a9c55d26a1d3ab402284b741c7448618e8f88e5fe691b1237e42a"
+        "sha1": "SSHFP 1 1 b836981a1d246e48cd5577e257545ac8ef9c63c3",
+        "sha256": "SSHFP 1 2 d59cdbfccdcde30f959a1dc6195d5e54ab76802800c9fcef6c748ca697735708"
       },
-      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDPe/oTRHxI9mkjzQEGb3zBr3Gaco9t09Oag9XzIvsi5/ZWCBbZoBZVgKsQZbknLstjfUnP/Nm9cdFA04q++ytUVVNQfVcjjpsNh9v/niOLUKTB5NqzuE3nAVBQaVS3G9CczkYhA+ge+fSWmY5EAEzVkVhjtpwO5VrK0mxr4Q8XFnfcvxxcXacVazCVM7yh2mzrkHRL2/mu2GJZeBsT7HnWl8lyU1yPqF0CpzZXG3JIVMVy4ZjmCx3suE46y1Je6n6Dr76OrLOy2KClx2+T6xzECcOOlpVLayxiP4kcZa1CzCtvsUDynO21Gp6h6S0QO/CSc09jERvULvpsl5jHs6Lt"
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDOZqEYyOU8hXsx0Y/74wkY67LYJfsr9mhgX2B7moQKCinCL9e2jvwhXYNo1dF+mAp2qNa9K96YEG9G6U/Xaf/pCmQ3c0q+omDeInMzLr9mmgH7SZLdTr4NlyTl3sDZvpKepN9+CUxyf5gVYXvAFoFiIecxXC96d2oqvta/ljnJh26tMGfBL3Il8kTxqwMwaImSalLgi9239W+SM4yuk+10QAzpNhr1JlrhWeVHttxQbifx4oRBf88wrZlYBNp1QcPoQbcuFPuJXoPC3J94QmhL7Mh+K2j/IOZf/hZ/ZjYdQwFXPoYellMJwPQy6FjP/ht139MNL7uB53evw6BGwX0e/8dWS1FqToK4djF8ci2LQ03XXXKK6vVy8ypWwHWGNXSd9sehwyfHF0Xylx+4xnWJ1ySoYIHCUiOiusklYFvZC+sgKUK/VFN/q7S98oZDlkwAhNuUrR5gw2uThA83U0rEDqvTavgMWsEycQ0fEi0SNWG40fqrVVPjIx2CYYBeQkU=",
+      "type": "ssh-rsa"
     }
   },
+  "sshdsakey": "AAAAB3NzaC1kc3MAAACBAPiwPPwnebfeoRN1I8OnPYy4HpUZcbWBOY04iwPc2cZuFtkCvuw+gJPkeY6YxeZdNH5kTkZxqWPv2hs8SHWoh4CD+GeG0yfFmKbPYOCCyeU6nmm99SDuFP6R0Ogbx4fsqTkTBFCOZBlRizf+XNCIvIXsY0wu1AaN/1nuw92ukXqBAAAAFQD0Yt4V24h7HTR+sVh+yQPI5H+TawAAAIAb90fPshJB1cOggwklhtfD8lmXpif5k007asLNqsN0ai7vJue3cxxizmXZ5kt6/tYtnFUwW/E7kp7A4Fy0P3uxoFx5QxIBjaBEh0QPlGPvGOJ/L9uH727hVG557Xv4ScKGqOLVK1quYMxkItRwK3xMewGDIrpbvXyCRvXxZgcwswAAAIEA8xikmNqoSMPzS/9uGlDhMoChcqACaALJn+cWRrf3chMc3ox3LH8W6w5koXofXUpN/S481l3hszoNMuX8JRKROWoBBkYaohOtSvuDzJz7Sku3owNKIEvPecFffYQ6CcbPLc0Z0zPQshFo9ny+A2V040JTQxlF+iv1B49CB43xjBs=",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDfkrDP0uirsivVd1pib+bOL62pluqaXKV3aEs/hVCU3zvar5NILZJXnTBynsUZ8TPCyjKpS0dEW6PlJaoeQGuI=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIOGmEoGAMVm3P264nKeiz37e/cT1NXlrVvN/+k0XT/ls",
+  "sshfp_dsa": "SSHFP 2 1 a0c65effb04d04954bb4d09d53db282f9aca790d\nSSHFP 2 2 fd47b56f405a89f9e941d15a1559742389759aad6ea1ab6d965a806efda77b04",
+  "sshfp_ecdsa": "SSHFP 3 1 ea6f05fde6d599793074cc4de596bae3d516b2ed\nSSHFP 3 2 77bf426f6a78918845431402dc249f12b80a5d3aa7326564f61c16d9712f180b",
+  "sshfp_ed25519": "SSHFP 4 1 7038e89f3142c34fbaf0b3e86c430662777cb8f8\nSSHFP 4 2 9149930a442825395673739a8d1bea14cd7cf0c89c72908c4ef6c67a2557dc59",
+  "sshfp_rsa": "SSHFP 1 1 b836981a1d246e48cd5577e257545ac8ef9c63c3\nSSHFP 1 2 d59cdbfccdcde30f959a1dc6195d5e54ab76802800c9fcef6c748ca697735708",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDOZqEYyOU8hXsx0Y/74wkY67LYJfsr9mhgX2B7moQKCinCL9e2jvwhXYNo1dF+mAp2qNa9K96YEG9G6U/Xaf/pCmQ3c0q+omDeInMzLr9mmgH7SZLdTr4NlyTl3sDZvpKepN9+CUxyf5gVYXvAFoFiIecxXC96d2oqvta/ljnJh26tMGfBL3Il8kTxqwMwaImSalLgi9239W+SM4yuk+10QAzpNhr1JlrhWeVHttxQbifx4oRBf88wrZlYBNp1QcPoQbcuFPuJXoPC3J94QmhL7Mh+K2j/IOZf/hZ/ZjYdQwFXPoYellMJwPQy6FjP/ht139MNL7uB53evw6BGwX0e/8dWS1FqToK4djF8ci2LQ03XXXKK6vVy8ypWwHWGNXSd9sehwyfHF0Xylx+4xnWJ1ySoYIHCUiOiusklYFvZC+sgKUK/VFN/q7S98oZDlkwAhNuUrR5gw2uThA83U0rEDqvTavgMWsEycQ0fEi0SNWG40fqrVVPjIx2CYYBeQkU=",
+  "swapfree": "1.91 GiB",
+  "swapfree_mb": 1960.484375,
+  "swapsize": "1.92 GiB",
+  "swapsize_mb": 1962.99609375,
   "system_uptime": {
     "days": 0,
     "hours": 0,
-    "seconds": 96,
-    "uptime": "0:01 hours"
+    "seconds": 268,
+    "uptime": "0:04 hours"
   },
   "timezone": "UTC",
+  "uptime": "0:04 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 268,
+  "uuid": "eb6e0002-bde8-4896-b25f-780ea4ce4e2d",
   "virtual": "virtualbox"
 }

--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -66,7 +66,6 @@ describe 'Default Facts' do
     'facts/1.6/fedora-19-x86_64.facts' => 'unable to regenerate facts',
     'facts/2.1/archlinux-x86_64.facts' => 'no ifconfig package',
     'facts/3.10/ubuntu-18.04-aarch64.facts' => 'unable to regenerate facts',
-    'facts/3.9/archlinux-x86_64.facts' => 'no ifconfig package',
     'facts/1.6/archlinux-x86_64.facts' => 'no ifconfig package',
     'facts/2.4/archlinux-x86_64.facts' => 'no ifconfig package',
     'facts/3.2/aix-61-powerpc.facts' => 'unable to regenerate facts',


### PR DESCRIPTION
For reasons I don't know, the legacy facts were missing. I fixed it for 3.14. If I find some time later I will have a look at the other ones.