### PR TITLE
drop json as runtime dependency

### DIFF
--- a/facterdb.gemspec
+++ b/facterdb.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'github_changelog_generator', '~> 1.10', '< 1.10.4'
-  s.add_runtime_dependency 'json' if RUBY_VERSION =~ /^1\.8/
   s.add_runtime_dependency 'facter'
   s.add_runtime_dependency 'jgrep'
 end


### PR DESCRIPTION
This is only required on Ruby 1.8 and ever worked as expected. It won't
be included as dependency UNLESS we build it on Ruby 1.8.