### PR TITLE
Add ruby 2.5 and 2.7 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,27 @@ sudo: false
 cache: bundler
 script:
 - bundle exec rake spec
-rvm:
-- 2.3
-env:
-- FACTER_GEM_VERSION="~> 1.6.0"
-- FACTER_GEM_VERSION="~> 1.7.0"
-- FACTER_GEM_VERSION="~> 2.0.0"
-- FACTER_GEM_VERSION="~> 2.1.0"
-- FACTER_GEM_VERSION="~> 2.2.0"
-- FACTER_GEM_VERSION="~> 2.3.0"
-- FACTER_GEM_VERSION="~> 2.4.0"
-- FACTER_GEM_VERSION="~> 2.0" COVERAGE=yes
 matrix:
   fast_finish: true
+  include:
+  - rvm: 2.3
+    env: FACTER_GEM_VERSION="~> 1.6.0"
+  - rvm: 2.3
+    env: FACTER_GEM_VERSION="~> 1.7.0"
+  - rvm: 2.3
+    env: FACTER_GEM_VERSION="~> 2.0.0"
+  - rvm: 2.3
+    env: FACTER_GEM_VERSION="~> 2.1.0"
+  - rvm: 2.3
+    env: FACTER_GEM_VERSION="~> 2.2.0"
+  - rvm: 2.3
+    env: FACTER_GEM_VERSION="~> 2.3.0"
+  - rvm: 2.3
+    env: FACTER_GEM_VERSION="~> 2.4.0"
+  - rvm: 2.5
+    env: FACTER_GEM_VERSION="~> 2.0" COVERAGE=yes
+  - rvm: 2.7
+    env: FACTER_GEM_VERSION="~> 2.0"
 notifications:
   email: false
 deploy:


### PR DESCRIPTION
This change unrolls the travis test matrix to add testing with ruby
2.5 and ruby 2.7, to avoid regressions with ruby versions that puppet
ships currently or in the future.