### PR TITLE
Remove pin on facter < 4

### DIFF
--- a/facterdb.gemspec
+++ b/facterdb.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'github_changelog_generator', '~> 1.10', '< 1.10.4'
-  s.add_runtime_dependency 'facter', '< 4.0.0'
+  s.add_runtime_dependency 'facter'
   s.add_runtime_dependency 'jgrep'
 end

--- a/facterdb.gemspec
+++ b/facterdb.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'github_changelog_generator', '~> 1.10', '< 1.10.4'
-  s.add_runtime_dependency 'facter'
+  s.add_runtime_dependency 'facter', '< 5.0.0'
   s.add_runtime_dependency 'jgrep'
 end


### PR DESCRIPTION
`facter` was pinned to `< 4` in https://github.com/camptocamp/facterdb/pull/151. If you are using `facter >= 4` you will get version `1.2.0` of `facterdb` which can cause issues on some platforms (notably Solaris) due to data missing for it that was introduced in a later version of `facterdb`. See [this thread](https://puppetcommunity.slack.com/archives/C113FRBRU/p1593082270125500) in the Puppet Community [#puppet](https://puppetcommunity.slack.com/archives/C0W298S9G) Slack channel.

Given Facter 4 has been out in the wild for a bit now, I was hoping we could remove this pin?

