### PR TITLE
Fixes #19 - add filter validation

### DIFF
--- a/spec/facterdb_spec.rb
+++ b/spec/facterdb_spec.rb
@@ -282,6 +282,16 @@ describe FacterDB do
     end
   end
 
+  describe '.valid_filters?' do
+    it 'invalid and false' do
+      expect( FacterDB.valid_filters?('and')).to be_falsey
+    end
+
+    it 'valid and true' do
+      expect( FacterDB.valid_filters?('foo')).to be_truthy
+    end
+  end
+
   describe '.get_facts' do
     subject(:result) { FacterDB.get_facts(filter) }
 


### PR DESCRIPTION
* Previously there was not a way to validate if a filter was
  legit or not.  This adds a new method that exposes the jgrep
  validation interface to facterdb.

  Additionally, it also refactors the get_facts method by adding
  an intermediary method to generate the filter string.

  I have also added a new error class for throwing a better error
  message to the user.

  Lastly, I added some method documention for all the methods I touched.