### PR TITLE
Fixes a bug with generate_filter_str

### DIFF
--- a/lib/facterdb.rb
+++ b/lib/facterdb.rb
@@ -97,7 +97,7 @@ module FacterDB
 
   # @return [String] - the string filter
   # @param filter [Object] - The filter to convert to jgrep string
-  def generate_filter_str(filter=nil)
+  def self.generate_filter_str(filter=nil)
     case filter
     when ::Array
       '(' + filter.map { |f| f.map { |k,v | "#{k}=#{v}" }.join(' and ') }.join(') or (') + ')'

--- a/spec/facterdb_spec.rb
+++ b/spec/facterdb_spec.rb
@@ -292,6 +292,32 @@ describe FacterDB do
     end
   end
 
+  describe '.generate_filter_str' do
+    it 'invalid type' do
+      expect{FacterDB.generate_filter_str(3)}.to raise_error(FacterDB::Errors::InvalidFilter)
+    end
+
+    it 'with string' do
+      expect(FacterDB.generate_filter_str('foo')).to eq("foo")
+    end
+
+    it 'with hash' do
+        expect(FacterDB.generate_filter_str({:osfamily => 'Debian'})).to eq("osfamily=Debian")
+    end
+
+    it 'with Array' do
+      expect(FacterDB.generate_filter_str([:osfamily => 'Debian'])).to eq("(osfamily=Debian)")
+    end
+
+    it 'empty' do
+      expect(FacterDB.generate_filter_str('')).to eq('')
+    end
+
+    it 'nil filter' do
+      expect(FacterDB.generate_filter_str(nil)).to eq('')
+    end
+  end
+
   describe '.get_facts' do
     subject(:result) { FacterDB.get_facts(filter) }
 


### PR DESCRIPTION
* previously the generate_filter_str method was not exposed as a class method
    and therefor was not found when being called through other methods.  This Fixes
    that by making it a class method.

I left out the `self.` from the method in previous commit.  I assumed the tests would have caught this but I think the tests are not really exercising the code correctly otherwise this error would have been caught. I added some tests to cover my method directly but I think there are some holes in the coverage as this error should have been caught before. 