### PR TITLE
facts_spec: Pathname class is missing

### DIFF
--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'digest'
+require 'pathname'
 
 RSpec::Matchers.define :have_a_unique_hash do
   match do |actual|


### PR DESCRIPTION
In debian's CI environment, running the spec tests fails with the
following error:

    RUBYLIB=. GEM_PATH=/<<PKGBUILDDIR>>/debian/facterdb/usr/share/rubygems-integration/all:/<<PKGBUILDDIR>>/debian/.debhelper/generated/_source/home/.local/share/gem/ruby/2.7.0:/var/lib/gems/2.7.0:/usr/local/lib/ruby/gems/2.7.0:/usr/lib/ruby/gems/2.7.0:/usr/lib/x86_64-linux-gnu/ruby/gems/2.7.0:/usr/share/rubygems-integration/2.7.0:/usr/share/rubygems-integration/all:/usr/lib/x86_64-linux-gnu/rubygems-integration/2.7.0 ruby2.7 -S rake -f debian/ruby-tests.rake
    /usr/bin/ruby2.7 -I/usr/share/rubygems-integration/all/gems/rspec-support-3.9.3/lib:/usr/share/rubygems-integration/all/gems/rspec-core-3.9.2/lib /usr/share/rubygems-integration/all/gems/rspec-core-3.9.2/exe/rspec --pattern ./spec/\*\*/\*_spec.rb --format documentation

    An error occurred while loading ./spec/facts_spec.rb.
    Failure/Error: project_dir = Pathname.new(__dir__).parent

    NameError:
      uninitialized constant Pathname
    # ./spec/facts_spec.rb:84:in `block in <top (required)>'
    # ./spec/facts_spec.rb:42:in `<top (required)>'

    Finished in 0.00003 seconds (files took 0.16545 seconds to load)
    0 examples, 0 failures, 1 error occurred outside of examples

To fix this we simply need to make sure that the 'pathname' stdlib is
"require"d at the top of the file.