### PR TITLE
Remove `clientX` facts from solaris factsets

### DIFF
--- a/facts/3.11/solaris-10-i86pc.facts
+++ b/facts/3.11/solaris-10-i86pc.facts
@@ -596,8 +596,5 @@
   "zonename": "global",
   "zones": 1,
   "zpool_featurenumbers": "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32",
-  "zpool_version": "32",
-  "clientcert": "myhostname.example.com",
-  "clientversion": "5.5.14",
-  "clientnoop": false
+  "zpool_version": "32"
 }

--- a/facts/3.11/solaris-11-i86pc.facts
+++ b/facts/3.11/solaris-11-i86pc.facts
@@ -640,8 +640,5 @@
   "zonename": "global",
   "zones": 1,
   "zpool_featurenumbers": "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35",
-  "zpool_version": "35",
-  "clientcert": "foo.example.com",
-  "clientversion": "5.5.18",
-  "clientnoop": false
+  "zpool_version": "35"
 }

--- a/facts/3.11/solaris-11-sun4v.facts
+++ b/facts/3.11/solaris-11-sun4v.facts
@@ -611,8 +611,5 @@
   "zonename": "global",
   "zones": 1,
   "zpool_featurenumbers": "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37",
-  "zpool_version": "37",
-  "clientcert": "foo.example.com",
-  "clientversion": "5.5.18",
-  "clientnoop": false
+  "zpool_version": "37"
 }

--- a/facts/3.14/solaris-11-i86pc.facts
+++ b/facts/3.14/solaris-11-i86pc.facts
@@ -640,8 +640,5 @@
   "zonename": "global",
   "zones": 1,
   "zpool_featurenumbers": "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35",
-  "zpool_version": "35",
-  "clientcert": "foo.example.com",
-  "clientversion": "6.12.0",
-  "clientnoop": false
+  "zpool_version": "35"
 }

--- a/facts/3.14/solaris-11-sun4v.facts
+++ b/facts/3.14/solaris-11-sun4v.facts
@@ -611,8 +611,5 @@
   "zonename": "global",
   "zones": 1,
   "zpool_featurenumbers": "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37",
-  "zpool_version": "37",
-  "clientcert": "foo.example.com",
-  "clientversion": "6.12.0",
-  "clientnoop": false
+  "zpool_version": "37"
 }

--- a/facts/3.9/solaris-10-i86pc.facts
+++ b/facts/3.9/solaris-10-i86pc.facts
@@ -17,9 +17,6 @@
   "blockdevices": "sd1,sd0",
   "chassisassettag": "ABC12345",
   "chassistype": "0x17 (rack mount chassis)",
-  "clientcert": "hostname.example.com",
-  "clientnoop": false,
-  "clientversion": "5.3.5",
   "defaultroute": "10.16.100.254",
   "disks": {
       "sd0": {


### PR DESCRIPTION
These are facts normally set by the puppet agent.
https://puppet.com/docs/puppet/5.5/lang_facts_and_builtin_vars.html#puppet-agent-facts

`clientversion`, `clientcert` have dedicated handling in rspec-puppet to
set them correctly.
https://github.com/rodjek/rspec-puppet/blob/f2e05f4a480a0d859121f5cab2dc5a70eb82d10a/lib/rspec-puppet/support.rb#L245

I found that the hardcoded values leads to a mismatch between the
puppet version being tested and the value of `clientversion`.

Specifically, it caused testing a module using concat with Puppet 5 to
explode [here](https://github.com/puppetlabs/puppetlabs-concat/blob/b98de457a364908417b454f906a3ad5224bb04b9/manifests/fragment.pp#L47)
(`Deferred` is not a valid type until Puppet 6).

These facts are not present in any other fact files.